### PR TITLE
Ignore build fails of non-dependee module build failures when publishing snapshots

### DIFF
--- a/release/src/publish/publish.bal
+++ b/release/src/publish/publish.bal
@@ -156,6 +156,7 @@ function isWorkflowRunSuccess(map<json> payload, commons:Module module) returns 
         commons:logAndPanicError(message, e);
     } else {
         log:printWarn(message + " Conclusion: " + conclusion);
+        return true; // Returning true, since we don't want these builds succeed to continue to the next level.
     }
     return false;
 }


### PR DESCRIPTION
## Description

Since now we are checking each of the module build statuses in order to proceed with the build process, there are two cases we have to consider:
1. The modules that have dependents.
2. Modules that don't have dependents.

When a module does not have any dependent, it's not necessary for that module to succeed to continue the process. This PR will consider that case, and when a module build is failed, if it does not have any dependents, the build process will continue. 