### PR TITLE
Remove module-ballerina-ldap from pipeline

### DIFF
--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -17,7 +17,6 @@
         "module-ballerina-jsonutils",
         "module-ballerina-jwt",
         "module-ballerinax-kafka",
-        "module-ballerina-ldap",
         "module-ballerina-log",
         "module-ballerina-math",
         "module-ballerina-mime",


### PR DESCRIPTION
Remove module-ballerina-ldap from pipeline with the Ballerina Authn/Authz desing for Swan Lake release [1].
[1] https://docs.google.com/document/d/1dGw5uUP6kqZNTwMfQ_Ik-k0HTMKhX70XpEA3tys9_kk/edit?usp=sharing

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/718
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584