### PR TITLE
Update stdlib dependabot to create single PR for all dependent modules

### DIFF
--- a/dependabot/update_repositories.py
+++ b/dependabot/update_repositories.py
@@ -162,6 +162,15 @@ def updatePropertiesFile(data, module, latestVersion):
                     modifiedLine = 'stdlib' + module.split('-')[-1].capitalize() + 'Version=' + latestVersion + "\n"
                 modifiedData += modifiedLine
                 commitFlag = True
+        elif module.split('-')[-1] == 'oauth2' and 'stdlibOAuth2Version' in line:
+            currentVersion = line.split('=')[-1].split('-')[0]
+            if compareVersion(latestVersion, currentVersion) == 1:
+                if 'SNAPSHOT' in line:
+                    modifiedLine = 'stdlibOAuth2Version=' + latestVersion + "-SNAPSHOT\n"
+                else:
+                    modifiedLine = 'stdlibOAuth2Version=' + latestVersion + "\n"
+                modifiedData += modifiedLine
+                commitFlag = True
         else:
             modifiedLine = line + '\n'
             modifiedData += modifiedLine

--- a/dependabot/update_repositories.py
+++ b/dependabot/update_repositories.py
@@ -194,13 +194,14 @@ def commitChanges(data, currentVersion, repo, module, latestVersion):
 
     # If branch already exists checkout and commit else create new branch from master branch and commit
     try:
-        source = repo.get_branch(branch=dependabotBranchName)
+        source = repo.get_branch("main")
     except GithubException:
-        try:
-            source = repo.get_branch("main")
-        except GithubException:
-            source = repo.get_branch("master")
+        source = repo.get_branch("master")
 
+    try:
+        repo.get_branch(branch=dependabotBranchName)
+        repo.merge(dependabotBranchName, source.commit.sha, "Sync default branch")
+    except:
         repo.create_git_ref(ref=f"refs/heads/" + dependabotBranchName, sha=source.commit.sha)
 
     contents = repo.get_contents("gradle.properties", ref=dependabotBranchName)

--- a/dependabot/update_repositories.py
+++ b/dependabot/update_repositories.py
@@ -10,11 +10,14 @@ from github import Github, InputGitAuthor, GithubException
 HTTP_REQUEST_RETRIES = 3
 HTTP_REQUEST_DELAY_IN_SECONDS = 2
 HTTP_REQUEST_DELAY_MULTIPLIER = 2
+
 packageUser =  os.environ["packageUser"]
 packagePAT = os.environ["packagePAT"]
 packageEmail =  os.environ["packageEmail"]
 organization = 'ballerina-platform'
+
 dependabotBranchName = 'stdlib-dependabot'
+pullRequestTitle = '[Automated] Bump stdlib module versions'
 
 def main():
     modulesWithVersionUpdates = preprocessString()
@@ -219,18 +222,18 @@ def createPullRequest(repo, currentVersion, module, latestVersion):
 
     # Check if a PR already exists for the module
     for pull in pulls:
-        if "Bump stdlib module versions" in pull.title:
+        if pullRequestTitle in pull.title:
             prExists = pull.number
 
     # Create a new PR if PR doesn't exist
     if prExists == 0:
         try:
-            repo.create_pull(title="Bump stdlib module versions", 
+            repo.create_pull(title=pullRequestTitle, 
                             body='$subject', 
                             head=dependabotBranchName, 
                             base="main")
         except GithubException:
-            repo.create_pull(title="Bump stdlib module versions", 
+            repo.create_pull(title=pullRequestTitle, 
                             body='$subject', 
                             head=dependabotBranchName, 
                             base="master")


### PR DESCRIPTION
With this update, Ballerina Stdlib Dependabot will only create a single PR for all the dependent modules in each Stdlib module repository. 