### PR TITLE
Add default branch sync before stdlib version update in Ballerina Distribution

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -58,7 +58,6 @@ jobs:
                     fi
 
             -   name: Update Ballerina Distribution
-                if : steps.commit.outputs.changes
                 run: |
                     cd ballerina-standard-library
                     python release/src/version_update/main.py


### PR DESCRIPTION
Sync `automated-stdlib-version-update` branch with the default branch in Ballerina Distribution.