### PR TITLE
Improve dependency graph generator

### DIFF
--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -1,41 +1,118 @@
 {
     "modules": [
-        "module-ballerina-auth",
-        "module-ballerina-cache",
-        "module-ballerina-crypto",
-        "module-ballerina-email",
-        "module-ballerina-file",
-        "module-ballerina-ftp",
-        "module-ballerina-graphql",
-        "module-ballerina-grpc",
-        "module-ballerina-http",
-        "module-ballerina-io",
-        "module-ballerinax-java.jdbc",
-        "module-ballerina-jballerina.java.arrays",
-        "module-ballerina-jwt",
-        "module-ballerinax-kafka",
-        "module-ballerina-log",
-        "module-ballerina-mime",
-        "module-ballerinax-mysql",
-        "module-ballerinax-nats",
-        "module-ballerina-oauth2",
-        "module-ballerina-os",
-        "module-ballerinax-rabbitmq",
-        "module-ballerina-random",
-        "module-ballerina-regex",
-        "module-ballerina-sql",
-        "module-ballerinax-stan",
-        "module-ballerina-task",
-        "module-ballerina-tcp",
-        "module-ballerina-time",
-        "module-ballerinai-transaction",
-        "module-ballerina-udp",
-        "module-ballerina-url",
-        "module-ballerina-uuid",
-        "module-ballerina-websocket",
-        "module-ballerina-websub",
-        "module-ballerina-websubhub",
-        "module-ballerina-xmldata",
-        "module-ballerina-xslt"
+        {
+            "name": "module-ballerina-auth"
+        },
+        {
+            "name": "module-ballerina-cache"
+        },
+        {
+            "name": "module-ballerina-crypto"
+        },
+        {
+            "name": "module-ballerina-email"
+        },
+        {
+            "name": "module-ballerina-file"
+        },
+        {
+            "name": "module-ballerina-ftp"
+        },
+        {
+            "name": "module-ballerina-graphql"
+        },
+        {
+            "name": "module-ballerina-grpc"
+        },
+        {
+            "name": "module-ballerina-http"
+        },
+        {
+            "name": "module-ballerina-io"
+        },
+        {
+            "name": "module-ballerinax-java.jdbc",
+            "version_key": "stdlibJdbcVersion"
+        },
+        {
+            "name": "module-ballerina-jballerina.java.arrays",
+            "version_key": "stdlibJavaArraysVersion"
+        },
+        {
+            "name": "module-ballerina-jwt"
+        },
+        {
+            "name": "module-ballerinax-kafka"
+        },
+        {
+            "name": "module-ballerina-log"
+        },
+        {
+            "name": "module-ballerina-mime"
+        },
+        {
+            "name": "module-ballerinax-mysql"
+        },
+        {
+            "name": "module-ballerinax-nats"
+        },
+        {
+            "name": "module-ballerina-oauth2",
+            "version_key": "stdlibOAuth2Version"
+        },
+        {
+            "name": "module-ballerina-os"
+        },
+        {
+            "name": "module-ballerinax-rabbitmq"
+        },
+        {
+            "name": "module-ballerina-random"
+        },
+        {
+            "name": "module-ballerina-regex"
+        },
+        {
+            "name": "module-ballerina-sql"
+        },
+        {
+            "name": "module-ballerinax-stan"
+        },
+        {
+            "name": "module-ballerina-task"
+        },
+        {
+            "name": "module-ballerina-tcp"
+        },
+        {
+            "name": "module-ballerina-time"
+        },
+        {
+            "name": "module-ballerinai-transaction"
+        },
+        {
+            "name": "module-ballerina-udp"
+        },
+        {
+            "name": "module-ballerina-url"
+        },
+        {
+            "name": "module-ballerina-uuid"
+        },
+        {
+            "name": "module-ballerina-websocket"
+        },
+        {
+            "name": "module-ballerina-websub"
+        },
+        {
+            "name": "module-ballerina-websubhub"
+        },
+        {
+            "name": "module-ballerina-xmldata"
+        },
+        {
+            "name": "module-ballerina-xslt"
+        }
     ]
 }

--- a/release/resources/stdlib_modules.json
+++ b/release/resources/stdlib_modules.json
@@ -5,6 +5,7 @@
             "version": "0.6.0-beta.2-SNAPSHOT",
             "level": 1,
             "default_branch": "master",
+            "version_key": "stdlibIoVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-log",
@@ -17,6 +18,7 @@
             "version": "0.10.0-beta.2-SNAPSHOT",
             "level": 1,
             "default_branch": "master",
+            "version_key": "stdlibJavaArraysVersion",
             "release": true,
             "dependents": []
         },
@@ -25,6 +27,7 @@
             "version": "0.10.0-beta.2-SNAPSHOT",
             "level": 1,
             "default_branch": "main",
+            "version_key": "stdlibRandomVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-websub"
@@ -35,6 +38,7 @@
             "version": "0.7.0-beta.2-SNAPSHOT",
             "level": 1,
             "default_branch": "main",
+            "version_key": "stdlibRegexVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-log",
@@ -46,6 +50,7 @@
             "version": "2.0.0-beta.2-SNAPSHOT",
             "level": 1,
             "default_branch": "master",
+            "version_key": "stdlibTimeVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-crypto",
@@ -58,12 +63,10 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 1,
             "default_branch": "master",
+            "version_key": "stdlibUrlVersion",
             "release": true,
             "dependents": [
-                "module-ballerina-graphql",
-                "module-ballerinai-transaction",
-                "module-ballerina-websub",
-                "module-ballerina-websubhub"
+                "module-ballerina-http"
             ]
         },
         {
@@ -71,6 +74,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 1,
             "default_branch": "master",
+            "version_key": "stdlibXmldataVersion",
             "release": true,
             "dependents": []
         },
@@ -79,6 +83,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 2,
             "default_branch": "master",
+            "version_key": "stdlibCryptoVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-auth",
@@ -95,6 +100,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 2,
             "default_branch": "master",
+            "version_key": "stdlibLogVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-auth",
@@ -114,6 +120,7 @@
             "version": "0.8.0-beta.2-SNAPSHOT",
             "level": 2,
             "default_branch": "master",
+            "version_key": "stdlibOsVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-file"
@@ -124,6 +131,7 @@
             "version": "2.0.0-beta.2-SNAPSHOT",
             "level": 2,
             "default_branch": "master",
+            "version_key": "stdlibTaskVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-cache",
@@ -136,6 +144,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 2,
             "default_branch": "master",
+            "version_key": "stdlibXsltVersion",
             "release": true,
             "dependents": []
         },
@@ -144,6 +153,7 @@
             "version": "2.1.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "master",
+            "version_key": "stdlibCacheVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-auth",
@@ -156,6 +166,7 @@
             "version": "0.7.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "master",
+            "version_key": "stdlibFileVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-email",
@@ -167,6 +178,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "master",
+            "version_key": "stdlibFtpVersion",
             "release": true,
             "dependents": []
         },
@@ -175,6 +187,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "master",
+            "version_key": "stdlibMimeVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-email",
@@ -186,6 +199,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "master",
+            "version_key": "stdlibNatsVersion",
             "release": true,
             "dependents": []
         },
@@ -194,6 +208,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "main",
+            "version_key": "stdlibStanVersion",
             "release": true,
             "dependents": []
         },
@@ -202,6 +217,7 @@
             "version": "0.8.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "master",
+            "version_key": "stdlibTcpVersion",
             "release": true,
             "dependents": []
         },
@@ -210,6 +226,7 @@
             "version": "0.9.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "main",
+            "version_key": "stdlibUdpVersion",
             "release": true,
             "dependents": []
         },
@@ -218,6 +235,7 @@
             "version": "0.10.0-beta.2-SNAPSHOT",
             "level": 3,
             "default_branch": "main",
+            "version_key": "stdlibUuidVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-http"
@@ -228,6 +246,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 4,
             "default_branch": "master",
+            "version_key": "stdlibAuthVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-http"
@@ -238,6 +257,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 4,
             "default_branch": "master",
+            "version_key": "stdlibEmailVersion",
             "release": true,
             "dependents": []
         },
@@ -246,6 +266,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 4,
             "default_branch": "master",
+            "version_key": "stdlibJwtVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-http"
@@ -256,6 +277,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 4,
             "default_branch": "master",
+            "version_key": "stdlibOAuth2Version",
             "release": true,
             "dependents": [
                 "module-ballerina-http"
@@ -266,6 +288,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 5,
             "default_branch": "master",
+            "version_key": "stdlibHttpVersion",
             "release": true,
             "dependents": [
                 "module-ballerina-graphql",
@@ -281,6 +304,7 @@
             "version": "0.2.0-beta.2-SNAPSHOT",
             "level": 6,
             "default_branch": "master",
+            "version_key": "stdlibGraphqlVersion",
             "release": true,
             "dependents": []
         },
@@ -289,6 +313,7 @@
             "version": "0.8.0-beta.2-SNAPSHOT",
             "level": 6,
             "default_branch": "master",
+            "version_key": "stdlibGrpcVersion",
             "release": true,
             "dependents": []
         },
@@ -297,6 +322,7 @@
             "version": "1.0.14-SNAPSHOT",
             "level": 6,
             "default_branch": "master",
+            "version_key": "stdlibTransactionVersion",
             "release": true,
             "dependents": [
                 "module-ballerinax-kafka",
@@ -309,6 +335,7 @@
             "version": "1.2.0-beta.2-SNAPSHOT",
             "level": 6,
             "default_branch": "main",
+            "version_key": "stdlibWebsocketVersion",
             "release": true,
             "dependents": []
         },
@@ -317,6 +344,7 @@
             "version": "1.2.0-beta.2-SNAPSHOT",
             "level": 6,
             "default_branch": "master",
+            "version_key": "stdlibWebsubVersion",
             "release": true,
             "dependents": []
         },
@@ -325,6 +353,7 @@
             "version": "0.2.0-beta.2-SNAPSHOT",
             "level": 6,
             "default_branch": "main",
+            "version_key": "stdlibWebsubhubVersion",
             "release": true,
             "dependents": []
         },
@@ -333,6 +362,7 @@
             "version": "2.1.0-beta.2-SNAPSHOT",
             "level": 7,
             "default_branch": "master",
+            "version_key": "stdlibKafkaVersion",
             "release": true,
             "dependents": []
         },
@@ -341,6 +371,7 @@
             "version": "1.1.0-beta.2-SNAPSHOT",
             "level": 7,
             "default_branch": "master",
+            "version_key": "stdlibRabbitmqVersion",
             "release": true,
             "dependents": []
         },
@@ -349,6 +380,7 @@
             "version": "0.6.0-beta.2-SNAPSHOT",
             "level": 7,
             "default_branch": "master",
+            "version_key": "stdlibSqlVersion",
             "release": true,
             "dependents": [
                 "module-ballerinax-java.jdbc",
@@ -360,6 +392,7 @@
             "version": "0.6.0-beta.2-SNAPSHOT",
             "level": 8,
             "default_branch": "master",
+            "version_key": "stdlibJdbcVersion",
             "release": true,
             "dependents": []
         },
@@ -368,6 +401,7 @@
             "version": "0.7.0-beta.2-SNAPSHOT",
             "level": 8,
             "default_branch": "master",
+            "version_key": "stdlibMysqlVersion",
             "release": true,
             "dependents": []
         }


### PR DESCRIPTION
$subject since it is recommended to only use platform level URL to identify packages repositories. Because of this, we cannot identify dependencies based on the repository URL. 

The script is improved to parse the gradle.properties file to identify the version key of each modules' dependencies. 

Default version_key is stdlib + Capitalised artifact Name + Version
This can be overridden in the modules.json.

Improvement because of https://github.com/ballerina-platform/ballerina-release/issues/547