### PR TITLE
Add the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+Ballerina project maintainers take security issues very seriously and all the vulnerability reports are treated with the highest priority and confidentiality.
+
+>**IMPORTANT:** Please use the **[security@ballerina.io](mailto:security@ballerina.io)** mailing list to report all security-related issues.
+
+For more information on the Security Policy of Ballerina, go to the [Security Policy](https://ballerina.io/security/).


### PR DESCRIPTION
## Purpose
This PR adds the "Security Policy" which explains how to report a security issue and refers to the detailed [Ballerina security policy](https://ballerina.io/security/). 

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/1849