### PR TITLE
Review and Improve the API Docs Guidelines

### DIFF
--- a/docs/api-documentation-guide.md
+++ b/docs/api-documentation-guide.md
@@ -1,4 +1,4 @@
-# The Standard Library API Documentation Guide
+# Standard Library API Documentation Guide
 
 _Authors_: @shafreenAnfar @daneshk @praneesha  
 _Reviewers_: @chamil321  

--- a/docs/api-documentation-guide.md
+++ b/docs/api-documentation-guide.md
@@ -133,9 +133,7 @@ For information on how to write better Ballerina code, see [Ballerina Anti-Patte
 
 5. You should NOT try to refer to the BBEs with links from within API Docs, but rather have separate examples. This is because the required examples will probably not match the examples in the BBEs. The API Docs should have more examples to explain each API operation etc. Also, you will not want to click another link and navigate away from the API docs to a separate BBE page. Rather, you will need to see the example in the same place where the module is described. 
 
-6. The examples in API Docs should be self-contained. They should contain a fully working program when an example is given, for example, including all the imports and a main function. The Ballerina documentation generator can later remove any redundant code segments in a post-processing operation. This is required since this code should be executable from the Ballerina website. 
-
-7. In scenarios such as error value returns, all possible error types and their scenarios should be mentioned clearly. There should NOT be statements such as “returns error when something goes wrong”. 
+6. In scenarios such as error value returns, all possible error types and their scenarios should be mentioned clearly. There should NOT be statements such as “returns error when something goes wrong”. 
 
 ## More Ballerina Doc Guidelines
 

--- a/docs/api-documentation-guide.md
+++ b/docs/api-documentation-guide.md
@@ -5,122 +5,138 @@ _Reviewers_: @chamil321
 _Created_: 2021/10/08  
 _Updated_: 2021/10/08
 
+- [Overview](https://github.com/ballerina-platform/ballerina-standard-library/edit/main/docs/api-documentation-guide.md#overview)
+- [Materializing the Above](https://github.com/ballerina-platform/ballerina-standard-library/edit/main/docs/api-documentation-guide.md#materializing-the-above)
+- [Linking BBEs from API Docs](https://github.com/ballerina-platform/ballerina-standard-library/edit/main/docs/api-documentation-guide.md#linking-bbes-from-api-docs)
+- [Guidelines and Best Practices](https://github.com/ballerina-platform/ballerina-standard-library/edit/main/docs/api-documentation-guide.md#guidelines-and-best-practices)
+- [Anti-Patterns](https://github.com/ballerina-platform/ballerina-standard-library/edit/main/docs/api-documentation-guide.md#anti-patterns)
+- [Additional Guidelines ](https://github.com/ballerina-platform/ballerina-standard-library/edit/main/docs/api-documentation-guide.md#additional-guidelines )
+- [More Ballerina Doc Guidelines](https://github.com/ballerina-platform/ballerina-standard-library/edit/main/docs/api-documentation-guide.md#more-ballerina-doc-guidelines)
+
 ## Overview
 
-API docs is another attribute that is authored, maintained and governed by the Standard Library team. This is the only official way in which the standard library team communicates about its module details in form of documentation. 
+API Docs is another attribute of Ballerina that is authored, maintained, and governed by the Standard Library team. This is the only official way in which the Standard Library team communicates the details of its modules in the form of documentation. 
 
-The key purpose of this document is to help developers understand a given standard library module when needed in a quick and easy way. Therefore the structure of this document no is different from a well written research paper, book or newspaper article. In each case you start from top to bottom. At the top we have the synopsis whereas at the bottom we have all the fine-grained details. Basically, as you continue downwards, the details increase until you have all the information. The same applies for API docs as well but expressed in a different way.
+The key purpose of API Docs is to help developers understand a Standard Library module in a quick and easy way. Therefore, the structure of them is organized in a top-down approach similar to a well written research paper, book, or newspaper article. Every module starts with the synopsis at the top and have all the fine-grained details explained towards the bottom. Basically, as you continue downwards, the details increase gradually until you have all the information. 
 
-Following is the high level structure of API documentation.
+The following is the high-level structure of API Documentation.
 
-- **Topic** - In this its the module name
-- **Overview** - A high level description of the module which includes things such as concepts, philosophies, standards, practises, motives, etc which we followed when designing the module. Once read one should be able to understand the overall purpose of this module as a whole. Basically this includes the synopsis of the package. 
-- **Sub Topics** - Once understood the high level purpose of the module. If interested,  developers can further dig deeper into understanding modules functions, objects, records, etc.
+- **Topic** - The module name.
+- **Overview** - A high-level description of the module, which includes concepts, philosophies, standards, practises, motives, etc., which were followed when designing the module. You should be able to understand the overall purpose of this module as a whole by reading this. Basically, this includes the synopsis of the module. 
+- **Sub Topics** - After the high-level purpose of the module is understood, you can dig deeper into understanding the functions, objects, records, etc. of the module.
 
-A good example for the above can be found in [1](https://pkg.go.dev/regexp#example_) and [2](https://docs.oracle.com/javase/7/docs/api/).
+A good example for the above can be found in the [GO Standard Library Docs](https://pkg.go.dev/regexp#example_) and [Java™ Platform, Standard Edition 7
+API Specification](https://docs.oracle.com/javase/7/docs/api/).
 
 ## Materializing the Above
 
-In order to materialize the above we need make use of three things,
+The three components below are used to materialize the above.
 
--  Package.md documentation 
-   -  This is all about the distribution of the modules. Rendered in Ballerina central but not in API docs of ballerina.io 
-   -  This can include stuff like a banner saying this is owned by the standard library team, version compatibility, release dates, governing principles, security validations, etc.
-- Module.md documentation 
-   -  Default Module.md 
-       - Module.md in the default acts as the root description. Basically this corresponds to what is discussed in point 2 above (Overview section). This includes the synopsis of this module. 
-   -  Other Module.md 
-      -  All the module files fall under point 3 above (Sub Topics) which includes a synopsis specific to that particular module.
-   - Can use code snippets if it helps solidify the message
-       - Remember to evolve those along with the code
-   -  Pointing to BBEs  (More on that later)
-- Code documentation 
-   -  Falls under point 3 above (Sub Topics). However, this is the leaf level information which basically completes the message. There is no other information that goes beyond this.
+1.  `Package.md` documentation 
+      -  This is all about the distribution of the modules. The content of this is rendered in Ballerina Central (but not in API Docs of [lib.ballerina.io`](https://lib.ballerina.io/)). 
+      -  This can include elements such as a banner mentioning that this is owned by the Standard Library team, the version compatibility, release dates, governing principles, security validations, etc.
+2. `Module.md` documentation 
+   -  Default `Module.md` file 
+       - By default, the `Module.md` file acts as the root description. Basically, this corresponds to the `Overview` section in API Docs. This includes the synopsis of this module. 
+   -  Other `Module.md` files 
+      -  All the other module files fall under the `Sub Topics` section, which will include a synopsis specific to that particular module.
+   - Use code snippets if it helps to solidify the message.
+       - Remember to evolve those along with the code.
+   -  Pointing to BBEs  (More on that later).
+3. Code documentation 
+   -  Falls under `Sub Topics`. However, this is the leaf-level information, which basically completes the message. There is no other information that goes beyond this.
 
+## Linking BBEs from API Docs 
 
+At the moment, some of the BBEs are authored, maintained, and governed by the Standard Library team.
 
-## Ballerina by Examples (BBEs)
+The purpose of the BBEs is to give a quick look and feel of Ballerina. These examples need to be short and sweet. You can start trying out Ballerina using these examples. Also, they can be used as reminders or quick reference. One BBE should only be used to explain one concept. You can dig deeper by referring API Docs or by using the Visual Studio Code tool itself, which provides other suggestions. Therefore, BBEs do not have to include every minor detail of the module. A good example would be the [UDP Client](https://ballerina.io/learn/by-example/udp-client.html). 
 
-At the moment some of the BBEs are authored, maintained and governed by the standard library team.
+BBEs and API Docs are two documents are completely different from each other and serve completely two different purposes. Therefore, linking API Docs to BBEs sort of breaks the flow of API Docs. If examples are needed to solidify the message, better to write them then and there.
 
-The purpose of this document is to give a quick look and feel of Ballerina. These examples need to be short and sweet. Developers can start trying out Ballerina using these examples. Also, can be used as a reminder or quick reference.
+Also, BBEs could be owned by an external entity (e.g., the DevRel team) and be evolved on their own whereas, API docs are always authored, maintained, and governed by the Standard Library team. However, if required, BBEs can be added as another section in API Docs as similar communities (e.g., GoLang) have done it.
 
-One BBE should only be used to explain one concept.
-
-If they are interested they can further dig deep by looking into API docs or by using VSCode tool itself which provides other sorts of suggestions.
-
-Therefore, we believe BBEs do not have to include every little detail of the module. A good example would be [1](https://ballerina.io/learn/by-example/udp-client.html). 
-
-## Linking BBEs from API Docs
-
-Those two documents are completely different from each other and serve completely two different purposes. Therefore linking API docs to BBEs sort of breaks the flow of API docs. 
-If examples are needed to solidify the message, better to write it then and there.
-
-Also, some day BBEs could be even owned by an external entity (ex. DevRel team) and be evolved on their own whereas API docs are alway authored, maintained and governed by the standar library team.
-
-If we are to add BBEs, I think we should do it as GoLang has done. Added it as another section of API docs.
-
-In fact, IMO, linking should be done the other way around. BBEs should be linked to API docs. Because BBEs are short and incomplete. Therefore if one wants to know more information about the particular module that person can refer to API docs.  
+In fact, as BBEs are short and do not explain the complete picture, they should be linked to API docs so that you can refer API docs to know more information about the particular module. 
 
 ## Guidelines and Best Practices
-- Do not add full stops for any of the parameter descriptions
-  - Incorrect: # + url - Target service URL.
-  - Correct:   # + url - Target service URL
-- Add full stops in the function/record/object/const descriptions (in comments).
-  -  Incorrect: # Attaches a service to the listener
-  -  Correct:   # Attaches a service to the listener.
-- Start all descriptions  with a capital letter (just for consistency as most are written like this now.)
-  -  Incorrect: + url - target service URL
-  -  Correct:   + url - Target service URL
--  Avoid repeating the 'returns' word when documenting the function returns. Just mention what is being returned.
-    -  Incorrect:   \# + return - Returns the response of the request or an error if failed to establish the communication with the upstream server 
-    -  Correct:   # + return - The response of the request or else an `http:Error` if failed to establish the communication with the upstream server
-   -  When you have more than one returned items:
-      -  \# + return - Generated string token,  an `auth:Error` occurred while generating the token, or else () if nothing is to be returned
-      -  \# + return - `true` if authentication is successful, `false` otherwise, or else an `auth:Error` occurred while authenticating the credentials.
--  Do NOT use "we" or "please" anywhere in technical docs. Always use the passive form or direct form to say "you need to...".
-   -  Incorrect: # For details, please see the WebSocket module.
-   -  Correct:   # For details, see the WebSocket module.
--  For comments, it should always be the singular form. "# Attaches.."
-   -  Incorrect: # Attach a service to the listener.
-   -  Correct:   # Attaches a service to the listener.
--  Can use code snippets if it helps solidify the message
-    - Remember to evolve those along with the code
-    - Pointing to BBEs  (More on that later)
-- Code documentation 
-   -  Falls under point 3 above (Sub Topics). However, this is the leaf level information which basically completes the message. There is no other information that goes beyond this.
--  Capitalize standard words like URL, HTTP, or JSON.
-   -  Incorrect: # Creates http server endpoints.
-   -  Correct:   # Creates HTTP server endpoints.
--  Add the Oxford comma before “and” or “or” in lists.
-   -  Incorrect: # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
-   -  Correct: # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`, or `mime:Entity[]`
-   -  Note: We do not need the Oxford comma when there are only 2 items in the list as follows. E.g.,
+1. Do NOT add full stops for any of the parameter descriptions.
+      - **Incorrect:** # + url - Target service URL.
+      - **Correct:**   # + url - Target service URL
+2. Add full stops in the function/record/object/method/constant descriptions (found in code comments).
+      -  **Incorrect:** # Attaches a service to the listener
+      -  **Correct:**   # Attaches a service to the listener.
+3. Start all descriptions with a capital letter (just for consistency as most are written like this now.)
+      -  **Incorrect:** + url - target service URL
+      -  **Correct:**  + url - Target service URL
+4.  Avoid repeating the `returns` word when documenting the function returns. Just mention what is being returned.
+      -  **Incorrect:**   \# + return - Returns the response of the request or an error if failed to establish the communication with the upstream server 
+      -  **Correct:**   # + return - The response of the request or else an `http:Error` if failed to establish the communication with the upstream server
+      -  When you have more than one returned items:
+         -  \# + return - Generated string token,  an `auth:Error` occurred while generating the token, or else () if nothing is to be returned
+         -  \# + return - `true` if authentication is successful, `false` otherwise, or else an `auth:Error` occurred while authenticating the credentials.
+5.  Do NOT use "we" or "please" anywhere in technical docs. Always, use the passive form or direct form to say "you need to...".
+      -  **Incorrect:** # For details, please see the WebSocket module.
+      -  **Correct:**   # For details, see the WebSocket module.
+6.  Keep comments in the singular form (e.g., "# Attaches..").
+      -  **Incorrect:** # Attach a service to the listener.
+      -  **Correct:**   # Attaches a service to the listener.
+7.  Use code snippets if it helps to solidify the message.
+      - Remember to evolve those along with the code.
+      - Do NOT link to BBEs from API Docs.
+8.  Capitalize standard words like URL, HTTP, or JSON.
+      -  **Incorrect:** # Creates http server endpoints.
+      -  **Correct:**   # Creates HTTP server endpoints.
+9.  Apply the title case to all the headings.
+      -  **Incorrect:**: # Remote methods associated with a `websocket:Service`
+      -  **Correct:**   # Remote Methods Associated with a `websocket:Service`
+10.  Add the Oxford comma before “and” or “or” in lists.
+      -  **Incorrect:** # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
+      -  **Correct:** # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`, or `mime:Entity[]`
+      -  **Note:** We do not need the Oxford comma when there are only 2 items in the list as follows. E.g.,
 
-```
-foo or bar
-foo, bar, or baz
-foo and bar
-foo, bar, and baz
-```
--  Capitalize all file extensions.
-   -  Examples: BAL, ZIP
--  For names of third party technologies, use the exact way they write it (Google and check). 
-   -  Examples: MySQL not Mysql 
--  Add one line code snippet if possible. E.g., https://ballerina.io/v1-2/learn/api-docs/ballerina/java/index.html#annotations.
--  All the referrings of records/objects/functions inside the API docs and Module.md should have the representation as `<module-name>:<type-name>` instead of `<type-name>`.
--  Any description related to the parameter goes beyond a single line, and should start with the starting position of the 1st line.
-   - Example: # + httpClient - Chain of different HTTP clients which provides the capability   
+         ```
+         foo or bar
+         foo, bar, or baz
+         foo and bar
+         foo, bar, and baz
+         ```
+11. Capitalize all file extensions.
+      -  **Examples:** BAL, ZIP
+12. Use backticks to highlight the keywords.
+      -  **Examples:** `websocket:Service`
+13. For names of third party technologies, use the exact way they write it (Google and check). 
+      -  **Examples:** `MySQL` not `Mysql` 
+14.  Add one-line code snippets where possible. E.g., https://ballerina.io/v1-2/learn/api-docs/ballerina/java/index.html#annotations.
+15.  All the referrences of records/objects/functions/methods inside the API docs and `Module.md` should have the representation as `<module-name>:<type-name>` instead of `<type-name>`.
+16.  Any description related to the parameter, which goes beyond a single line should start with the starting position of the 1st line.
+      - **Example:** # + httpClient - Chain of different HTTP clients which provides the capability   
     \# 		   for initiating contact with a remote HTTP service in resilient  
     \# 		   manner
--  Do not use the word “users” in the comments. Instead, address the users directly using the word “you”. E.g.,
-   -  Wrong: Users can also pass a key/value pair where the value is an error stack trace.
-   -  Right: You can also pass a key/value pair where the value is an error stack trace.
+17.  Do not use the word “users” in the comments. Instead, address the users directly using the word “you”. E.g.,
+      -  **Incorrect:** Users can also pass a key/value pair where the value is an error stack trace.
+      -  **Correct:** You can also pass a key/value pair where the value is an error stack trace.
 
 ## Anti-Patterns
-[This doc](https://docs.google.com/document/d/1y6QVqaZzZt9jMpYV4jP5WRS_W_KoC4y40Uuoh1ALu8E/edit?usp=sharing) basically explains how to write better Ballerina code.
+For information on how to write better Ballerina code, see [Ballerina Anti-Patterns](https://docs.google.com/document/d/1y6QVqaZzZt9jMpYV4jP5WRS_W_KoC4y40Uuoh1ALu8E/edit?usp=sharing).
 
 ## Additional Guidelines 
 
-[This link](https://github.com/ballerina-platform/ballerina-distribution/blob/master/doc-guidelines.md#ballerina-by-examples-guidelines) has additional information with regard to writing BBEs and API documentation.
+1. Study the basics and best practices in writing API Docs comments. For information, go to [Documenting Ballerina Code](https://ballerina.io/learn/documenting-ballerina-code/).
 
+2. API Docs need to explain what the module is about, when, and how it is used. It should not try to explain language features (e.g., error handling, concurrency, etc). The language-level features will have to be covered in the Learn pages. 
+
+3. Module-level documentation page needs to introduce the general concept of the module and the main APIs that are used. For example, in the I/O module, this would be the aspects such as the channels concept, how we have different types of channels etc., and their common behavior. 
+
+   Rust’s I/O API documentation](https://doc.rust-lang.org/std/io/index.html) is a good example for how similar communities have done this. After the module overview, for each object, record, function, a separate documentation page is added, which will contain their individual details and also their specific examples. For example, see [Struct std::io::Cursor](https://doc.rust-lang.org/std/io/struct.Cursor.html) and [Struct std::io::BufReader](https://doc.rust-lang.org/std/io/struct.BufReader.html). Some APIs that were featured in the main module page will need to again have their own examples in their respective page. Therefore, there will be some overlap of information in that area. 
+
+4. The examples in the API Docs need to be short. Mostly, shorter than BBEs. They usually explain a quick API operation and not a complete, end to end scenario. The same [Ballerina By Examples Guidelines](https://github.com/ballerina-platform/ballerina-distribution/blob/master/doc-guidelines.md#ballerina-by-examples-guidelines) should be used for API Docs as well to keep the examples simple and precise. 
+
+5. You should NOT try to refer to the BBEs with links from within API Docs, but rather have separate examples. This is because the required examples will probably not match the examples in the BBEs. The API Docs should have more examples to explain each API operation etc. Also, you will not want to click another link and navigate away from the API docs to a separate BBE page. Rather, you will need to see the example in the same place where the module is described. 
+
+6. The examples in API Docs should be self-contained. They should contain a fully working program when an example is given, for example, including all the imports and a main function. The Ballerina documentation generator can later remove any redundant code segments in a post-processing operation. This is required since this code should be executable from the Ballerina website. 
+
+7. In scenarios such as error value returns, all possible error types and their scenarios should be mentioned clearly. There should NOT be statements such as “returns error when something goes wrong”. 
+
+## More Ballerina Doc Guidelines
+
+For more information on Ballerina doc guidelines, see [Ballerina Doc Guidelines](https://github.com/ballerina-platform/ballerina-distribution/blob/master/doc-guidelines.md).


### PR DESCRIPTION
Review and improve the API Docs guidelines. 

Also, removed the duplicated API Docs guidelines from the `ballerina-distribution` repo and linked to this from it via https://github.com/ballerina-platform/ballerina-distribution/pull/2402 to avoid the duplication and ease the maintenance of the content.