### PR TITLE
Update load-test badge generation script

### DIFF
--- a/release/src/dependencies/utils.py
+++ b/release/src/dependencies/utils.py
@@ -20,7 +20,7 @@ def get_dashboard_row(module, level):
     codecov_badge = get_codecov_badge(module_name, default_branch)
     bugs_badge = get_bugs_badge(module_name)
     pull_requests_badge = get_pull_requests_badge(module_name)
-    load_tests_badge = get_load_tests_badge(module_name)
+    load_tests_badge = get_load_tests_badge(module_name, default_branch)
 
     return f'|{level}|{repo_link}|{release_badge}|{build_status_badge}|{trivy_badge}|{codecov_badge}|{bugs_badge}|{pull_requests_badge}|{load_tests_badge}|\n'
 
@@ -94,10 +94,14 @@ def get_bug_query(module_name):
     encoded_filter = urllib.parse.quote_plus(issue_filter)
     return f'{encoded_filter}&label=&color={label_colour}'
 
-def get_load_tests_badge(module_name):
+def get_load_tests_badge(module_name, default_branch):
+    # websub/websubhub load tests are in websubhub module, hence `websub` load-test badge should be same as `websubhub` load-test badge
+    if module_name == "module-ballerina-websub":
+        module_name = "module-ballerina-websubhub"
+        default_branch = "main"
     badge_url = f'{constants.GITHUB_BADGE_URL}/workflow/status/{constants.BALLERINA_ORG_NAME}/{module_name}/Process%20load%20test%20results?label='
     repo_url = f'{constants.BALLERINA_ORG_URL}/{module_name}/actions/workflows/process-load-test-result.yml'
-    workflow_file_url = f'{constants.GITHUB_RAW_LINK}/{constants.BALLERINA_ORG_NAME}/{module_name}/master/.github/workflows/process-load-test-result.yml'
+    workflow_file_url = f'{constants.GITHUB_RAW_LINK}/{constants.BALLERINA_ORG_NAME}/{module_name}/{default_branch}/.github/workflows/process-load-test-result.yml'
     try:
         urllib.request.urlopen(workflow_file_url)
     except:

--- a/release/src/dependencies/utils_test.py
+++ b/release/src/dependencies/utils_test.py
@@ -60,10 +60,10 @@ class TestDashboardCreation(unittest.TestCase):
 
     def test_get_load_tests_badge(self):
         expected = "[![Load Tests](https://img.shields.io/github/workflow/status/ballerina-platform/module-ballerina-io/Process%20load%20test%20results?label=)](https://github.com/ballerina-platform/module-ballerina-io/actions/workflows/process-load-test-result.yml)"
-        actual = utils.get_load_tests_badge(IO_MODULE)
+        actual = utils.get_load_tests_badge(IO_MODULE, "master")
         self.assertEqual(expected, actual)
         expected = "[![Load Tests](https://img.shields.io/badge/-N%2FA-yellow)](https://github.com/ballerina-platform/module-ballerina-jballerina.java.arrays/actions/workflows/process-load-test-result.yml)"
-        actual = utils.get_load_tests_badge(JAVA_ARRAYS_MODULE)
+        actual = utils.get_load_tests_badge(JAVA_ARRAYS_MODULE, "master")
         self.assertEqual(expected, actual)
 
     def test_get_row_without_level(self):


### PR DESCRIPTION
## Purpose
> $subject

This change is done to use the same load-test badge for WebSub and WebSubHub modules.