### PR TITLE
Fix Dependency Update Workflow Failure

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -31,12 +31,7 @@ jobs:
                     python-version: '3.x'
 
             -   name: Install Python packages
-                run: |
-                    pip install requests
-                    pip install networkx
-                    pip install retry
-                    pip install PyGithub
-                    pip install semver
+                run: pip install -r release/src/dependencies/requirements.txt
 
             -   name: Get Dependencies and update files
                 run: |

--- a/release/src/dependencies/requirements.txt
+++ b/release/src/dependencies/requirements.txt
@@ -1,0 +1,5 @@
+requests ~= 2.27
+networkx == 2.6.3
+retry == 0.9.2
+PyGithub ~= 1.55
+semver ~= 2.13

--- a/release/src/dependencies/utils.py
+++ b/release/src/dependencies/utils.py
@@ -1,5 +1,4 @@
 import json
-import os
 import sys
 import urllib.parse
 import urllib.request


### PR DESCRIPTION
The update stdlib dependency graph workflow was failing due to a version mismatch of a python module (`networkx`). 

This PR will fix the versions of the python modules to a particular version (tested and passed), to avoid these kind of failures in the future.