### PR TITLE
Update issue templates for updated labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/type_bug.md
+++ b/.github/ISSUE_TEMPLATE/type_bug.md
@@ -1,7 +1,7 @@
 ---
 name: "Bug Report"
 about: "Report a bug if something is not working as expected"
-labels: 'Type/Bug'
+labels: 'type/bug'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/type_improvement.md
+++ b/.github/ISSUE_TEMPLATE/type_improvement.md
@@ -1,7 +1,7 @@
 ---
 name: "Improvement Request"
 about: "Create an improvement request for an existing feature"
-labels: 'Type/Improvement'
+labels: 'type/improvement'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/type_new_feature.md
+++ b/.github/ISSUE_TEMPLATE/type_new_feature.md
@@ -1,7 +1,7 @@
 ---
 name: "New Feature Request"
 about: "Create a new feature request"
-labels: 'Type/NewFeature'
+labels: 'type/newFeature'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/type_proposal.md
+++ b/.github/ISSUE_TEMPLATE/type_proposal.md
@@ -1,7 +1,7 @@
 ---
 name: "Proposal"
 about: "Start a proposal for a new feature or an improvement"
-labels: 'Type/Proposal'
+labels: 'type/proposal'
 ---
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/type_task.md
+++ b/.github/ISSUE_TEMPLATE/type_task.md
@@ -1,7 +1,7 @@
 ---
 name: "Task"
 about: "Create a task which you want to keep track"
-labels: 'Type/Task'
+labels: 'type/task'
 
 ---
 


### PR DESCRIPTION
This PR updates the GitHub issue templates for the updated version of the `type/*` labels.