### PR TITLE
Update the Dashboard Generation to Send a PR

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -23,6 +23,8 @@ jobs:
                 run: |
                     git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
                     git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+                    git pull
+                    git checkout -b update-dependency-graph
 
             -   name: Update the Dependencies and Generate the Dashboard
                 uses: ballerina-platform/ballerina-action@2201.0.3
@@ -33,8 +35,56 @@ jobs:
                     WORKING_DIR: ./dashboard
                     BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
 
-            -   name: Commit files
+            -   name: Commit Files
+                id: commitFiles
                 run: |
                     git add -A
-                    git diff-index --quiet HEAD || git commit -m "[AUTOMATED] Update the dependency graph and the dashboard"
-                    git push
+                    if [[ git diff-index --quiet HEAD ]]
+                    then
+                        git commit -m "[AUTOMATED] Update the dependency graph and the dashboard"
+                        printf "::set-output name=hasChanged::true"
+                    else
+                        printf "::set-output name=hasChanged::false"
+                    fi
+
+            -   name: Push Results
+                if: ${{ steps.commitFiles.outputs.hasChanged }}
+                run: git push origin "update-dependency-graph"
+                env:
+                    GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+
+            -   name: Create Pull Request to Update the Dashboard
+                id: createPR
+                if: ${{ steps.processResults.outputs.hasPassed }}
+                run: printf "::set-output name=prUrl::$(gh pr create --title "[Automated] Update the Standard Library Dashboard" --body "Updating the standard library dashboard with latest changes")"
+                env:
+                    GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+
+            -   name: Approve PR
+                if: ${{ steps.commitFiles.outputs.hasChanged }}
+                run: |
+                    sleep 5
+                    gh pr review --approve ${{ steps.createPR.outputs.prUrl }}
+                env:
+                    GITHUB_TOKEN: ${{ secrets.BALLERINA_REVIEWER_BOT_TOKEN }}
+
+            -   name: Merge PR
+                if: ${{ steps.commitFiles.outputs.hasChanged }}
+                run: |
+                    checkCount="0"
+                    while [ "$checkCount" != "1" ]
+                    do
+                      sleep 20
+                      checkCount=$(gh pr status --jq '[.currentBranch .statusCheckRollup[] | select((.conclusion=="SUCCESS") and ((.name=="Build on Ubuntu")))] | length' --json statusCheckRollup)
+                      failedCount=$(gh pr status --jq '[.currentBranch .statusCheckRollup[] | select((.conclusion=="FAILURE") and ((.name=="Build on Ubuntu")))] | length' --json
+                      statusCheckRollup)
+                      if [[ "$failedCount" != "0" ]]
+                      then
+                        echo "PR Build has Failed"
+                        exit 1
+                      fi
+                    done
+                    sleep 20
+                    gh pr merge --merge --delete-branch
+                env:
+                    GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/dashboard/constants.bal
+++ b/dashboard/constants.bal
@@ -52,4 +52,4 @@ const DASHBOARD_TITLE = "## Status Dashboard";
 const README_HEADER = "| Level | Modules | Latest Version | Build | Security Check | Code Coverage | Bugs | Open PRs | Load Test Results |\n";
 const README_HEADER_SEPARATOR = "|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|\n";
 const BAL_TITLE = "## Ballerina Modules";
-const BALX_TITLE = "## Ballerina extended Modules";
+const BALX_TITLE = "## Ballerina Extended Modules";

--- a/dashboard/graph.bal
+++ b/dashboard/graph.bal
@@ -15,9 +15,9 @@
 // under the License.
 
 import ballerina/io;
-import ballerina/regex;
 import ballerina/lang.array;
 import ballerina/log;
+import ballerina/regex;
 
 type List record {|
     Module[] modules;
@@ -117,7 +117,7 @@ function getImmediateDependencies(List moduleDetails) returns error? {
         log:printInfo(string `Finding dependents of module ${module.name}`);
         string[] dependees = check getDependencies(module, moduleDetails);
 
-        // Get the dependecies modules which use module in there package 
+        // Get the dependecies modules which use module in there package
         foreach Module dependee in moduleDetails.modules {
             string dependeeName = dependee.name;
             string[]? dependeeDependents = dependee.dependents;

--- a/dashboard/remote.bal
+++ b/dashboard/remote.bal
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import ballerina/os;
 import ballerinax/github;
-import ballerina/http;
 
 int issueCount = 0;
 

--- a/dashboard/utils.bal
+++ b/dashboard/utils.bal
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import ballerina/regex;
 import ballerina/url;
-import ballerina/http;
 
 function getDashboardRow(Module module, string level) returns string|error {
     string moduleName = module.name;


### PR DESCRIPTION
## Purpose
Currently, when the dashboard is changed, it is directly committed and pushed to the `main` branch. But the branch protection rules do not allow this. Therefore, with this PR, it is configured to send a PR, and approve using the ballerina reviewer bot and then merge it.