### PR TITLE
Improve the Standard Library Full Build Script

### DIFF
--- a/resources/scripts/README.md
+++ b/resources/scripts/README.md
@@ -1,17 +1,17 @@
 # Standard Library Related Scripts
 
 ## Build Script
+
 > File Name: build_standard_library.py
 
 This script can be used to build the Ballerina Standard Library locally. It will build all the modules incrementally.
 
-If you already have cloned the standard library repos, you can provide the root directory of all the standard library
-repos to the script, so it will use the cloned repos. If any of the required repository is not found, script will clone them
-automatically to the provided location. This is a one time thing.
+If you already have cloned the standard library repos, you can provide the root directory of all the standard library repos to the script, so it will use the cloned repos. If any of the required repositories are not found, the script will clone them automatically to the provided location. This is a one-time thing.
 
 ### Usage
 
 #### Sample Usage
+
 ```shell
 python build_standard_library.py /Users/ballerina/standard-library --branch automated/dependency_version_update --skip-tests --module module-ballerina-http
 ```
@@ -27,56 +27,71 @@ python build_standard_library.py /Users/ballerina/standard-library --branch auto
 | Publish to local central | Optional | To publish all the modules to the local Ballerina central repo | `--publish-to-local-central` |
 | Skip Tests | Optional | Skip tests while building | `--skip-tests` |
 | Keep Local Changes | Optional | If this is not set, the repo will be hard reset to the origin branch. All the local changes will be overridden. | `--keep-local-changes` |
-| Build up to a Specific Module | Optional | If the build needs to be done up to a particular module, this flag can be used. The script will build all the modules up to the specified module. | `--module <module_repo_full_name_as_in_github>` |
+| Build up to a Specific Module | Optional | If the build needs to be done up to a particular module, this flag can be used. The script will build all the modules up to the specified module. | `--up-to-module <module name or the name of the module repository>` |
+| Build from a Specific Module | Optional | If the build needs to start from a different module than the starting module of the module list | `--from-module <<module name or the name of the module repository>` |
 | Custom Module List | Optional | If a custom module list needed to be used, the path to the module list can be passed using this flag. If not provided, the default [stdlib_modules.json](https://raw.githubusercontent.com/ballerina-platform/ballerina-standard-library/main/release/resources/stdlib_modules.json) file will be used. | `--module-list /path/to/module/list.json` |
 | Build the distribution | Optional | If provided, the ballerina-distribution repo will also be cloned and built. This is useful when a local lang change is needed and we need to check the distribution with it. Better to use this with `--snapshots-build` flag. | `--build-distribution` |
 | Using custom commands | Optional | The script uses `./gradlew clean build` as the default command (with skip tests, and publish flags when required). If a custom command is needed to be executed inside each repo, it can be provided using this flag | `--commands "./gradlew clean"` |
 | Skip Modules | Optional | To skip modules from building. The argument should be a comma separated list or a common word for the modules. Eg.: "nats, stan" or "ballerinax" | `--skip-modules <comma separated list of modules or a common string>` |
+| Continue on Fail | Optional | To continue when a particular module build fails. Default behavior is to stop the build | `--continue-on-error` |
 
 > Note: This script will only work with Python3. Some additional Python libraries may have to be downloaded before
   running the script. If there are any missing libraries, script will fail and the error will show what libraries
   are missing.
 
+#### To Test the Effect of a Local Lang Change
 
-#### To Test the Affect of a Local Lang Change
-* Do the lang change and build it, and publish it to the local maven repository. Executing the following command 
-  inside the `ballerina-lang` clone will publish the `SNAPSHOT` version of the language to the local maven repository.
+* Do the lang change and build it, and publish it to the local maven repository. Executing the following command inside the `ballerina-lang` clone will publish the `SNAPSHOT` version of the language to the local maven repository.
+
   ```shell
   ./gradlew build publishToMavenLocal
   ```
 
-* Then run the script with the `--lang-version <lang-snapshot-version>` flag. This will replace the
-  `ballerinaLangVersion` entry in every `gradle.properties` file of the standard library module when building them. 
-  For example, the following command will build the standard library repos using the `2.0.0-SNAPSHOT` version of the 
-  lang.
-    ```shell
-    python build_standard_library.py /Users/ballerina/standard-library --lang-version 2.0.0-SNAPSHOT
-    ```
+* Then run the script with the `--lang-version <lang-snapshot-version>` flag. This will replace the `ballerinaLangVersion` entry in every `gradle.properties` file of the standard library module when building them. For example, the following command will build the standard library repos using the `2.0.0-SNAPSHOT` version of the lang.
+
+  ```shell
+  python build_standard_library.py /Users/ballerina/standard-library --lang-version 2.0.0-SNAPSHOT
+  ```
 
 * When building the distribution, the ballerinax modules may not be needed to be built. They can be skipped using
   the `--skip-modules` flag.
+
   ```shell
-    python build_standard_library.py /Users/ballerina/standard-library --skip-modules "ballerinax"
-    ```
+  python build_standard_library.py /Users/ballerina/standard-library --skip-modules "ballerinax"
+  ```
+
   Alternatively, a set of modules can be skipped by providing the list of names:
-    ```shell
-    python build_standard_library.py /Users/ballerina/standard-library --skip-modules "nats, stan, kafka, rabbitmq"
-    ```
 
-* If you want to use the `SNAPSHOT` versions of the standard library modules to be used in the upper level modules, use
-  `--snapshots-build` flag. This will publish all the standard library modules to the local maven repository, and
-  replace the timestamp versions of the standard library module versions to SNAPSHOT versions in the `gradle.properties`
-  files.
-    ```shell
-    python build_standard_library.py /Users/ballerina/standard-library --snapshots-build
-    ```
+  ```shell
+  python build_standard_library.py /Users/ballerina/standard-library --skip-modules "nats, stan, kafka, rabbitmq"
+  ```
 
-* If you want to build a distribution pack on top of these changes, use `--build-distribution` flag. Example:
+* If you want to use the `SNAPSHOT` versions of the standard library modules to be used in the upper-level modules, use the `--snapshots-build` flag. This will publish all the standard library modules to the local maven repository, and replace the timestamp versions of the standard library module versions with SNAPSHOT versions in the `gradle.properties` files.
+
+  ```shell
+  python build_standard_library.py /Users/ballerina/standard-library --snapshots-build
+  ```
+
+* To build up to a particular module, use the `--up-to-module` flag. It takes a single argument which should be the complete name of the module repository.
+
+  ```shell
+  python build_standard_library.py /Users/ballerina/standard-library --up-to-module=module-ballerina-graphql
+  ```
+
+* To build from a particular module, use the `--up-to-module` flag. It takes a single argument which should be the complete name of the module repository.
+
+  ```shell
+  python build_standard_library.py /Users/ballerina/standard-library --from-module=module-ballerina-log
+  ```
+
+* If you want to build a distribution pack on top of these changes, use the `--build-distribution` flag. Example:
+
   ```shell
   python build_standard_library.py /Users/ballerina/standard-library --build-distribution
   ```
 
 * A complete example could be as follows:
+
     ```shell
     python build_standard_library.py /Users/ballerina/standard-library --snapshots-build --build-distribution --lang-version 2.0.0-SNAPSHOT --skip-modules "ballerinax" --publish-to-local-central
     ```

--- a/resources/scripts/build_standard_library.py
+++ b/resources/scripts/build_standard_library.py
@@ -24,26 +24,44 @@ TEMP_PROPERTIES = "temp.properties"
 GRADLE_PROPERTIES = "gradle.properties"
 
 # Argument Parser
-parser = argparse.ArgumentParser(description='Incrementally Build the Ballerina Standard Library')
+parser = argparse.ArgumentParser(
+    description='Incrementally Build the Ballerina Standard Library')
 
 # Mandatory Arguments
-parser.add_argument('path', help='Path to the directory where the standard library modules are (need to be) cloned')
+parser.add_argument(
+    'path', help='Path to the directory where the standard library modules are (need to be) cloned')
 
 # Optional arguments
-parser.add_argument('--lang-version', help='Ballerina language version to use for the builds')
-parser.add_argument('--branch', help='Branch to build. (Build will fail if the branch not found')
-parser.add_argument('--snapshots-build', action="store_true", help="Replace all the standard library dependent versions with 'SNAPSHOT' versions. This is helpfull to incrementally build libraries on top of a local change")
-parser.add_argument('--publish-to-local-central', action="store_true", help="Publish all the modules to the local ballerina central repository")
-parser.add_argument('--skip-tests', action="store_true", help="Skip tests in the builds")
-parser.add_argument('--keep-local-changes', action="store_true", help="Stop updating the repos from the origin. Keep the local changes")
-parser.add_argument('--module', help="Build up to the specified module")
-parser.add_argument('--module-list', help="Path to the module list JSON file. If not provided, the existing 'stdlib_modules.json' from the GitHub will be used")
-parser.add_argument('--build-distribution', action="store_true", help="If the distribution should be built on top of the changes been done. This has to be used with '--snapshots-build' to be affective")
-parser.add_argument('--commands', help="To provide a custom command to execute inside each repo. Provide this as a string. If not provided './gradlew clean build' will be used")
-parser.add_argument('--skip-modules', help="To provide a list of modules to be skipped. Provide this as a comma separated list. Even a part of the module name will be sufficient")
+parser.add_argument(
+    '--lang-version', help='Ballerina language version to use for the builds')
+parser.add_argument(
+    '--branch', help='Branch to build. (Build will fail if the branch not found')
+parser.add_argument('--snapshots-build', action="store_true",
+                    help="Replace all the standard library dependent versions with 'SNAPSHOT' versions. This is helpful to incrementally build libraries on top of a local change")
+parser.add_argument('--publish-to-local-central', action="store_true",
+                    help="Publish all the modules to the local ballerina central repository")
+parser.add_argument('--skip-tests', action="store_true",
+                    help="Skip tests in the builds")
+parser.add_argument('--keep-local-changes', action="store_true",
+                    help="Stop updating the repos from the origin. Keep the local changes")
+parser.add_argument('--up-to-module', help="Build up to the specified module")
+parser.add_argument('--from-module', help="Build from the specified module")
+parser.add_argument(
+    '--module-list', help="Path to the module list JSON file. If not provided, the existing 'stdlib_modules.json' from the GitHub will be used")
+parser.add_argument('--build-distribution', action="store_true",
+                    help="If the distribution should be built on top of the changes been done. This has to be used with '--snapshots-build' to be affective")
+parser.add_argument(
+    '--commands', help="To provide a custom command to execute inside each repo. Provide this as a string. If not provided './gradlew clean build' will be used")
+parser.add_argument(
+    '--skip-modules', help="To provide a list of modules to be skipped. Provide this as a comma separated list. Even a part of the module name will be sufficient")
+parser.add_argument('--continue-on-error', action="store_true",
+                    help="Whether to continue the subsequent builds when a module build fails")
+version_dict = {}
+
 
 def main():
     global MODULE_LIST
+    global version_dict
 
     args = parser.parse_args()
 
@@ -52,15 +70,18 @@ def main():
     branch = None
     use_snapshots = False
     keep_local_changes = False
-    required_module = None
+    up_to_module = None
+    from_module = None
     skip_modules = []
     build_distribution = args.build_distribution
+    continue_on_error = False
 
     print_block()
     print_info("Building Standard Library Modules")
 
     if not os.path.isdir(args.path):
-        print_info("Provided standard library module root directory does not exist. Creating the directory and cloning the repositories")
+        print_info(
+            "Provided standard library module root directory does not exist. Creating the directory and cloning the repositories")
         create_directory(args.path)
 
     os.chdir(args.path)
@@ -73,7 +94,7 @@ def main():
         print_info("Building the branch: " + args.branch)
         branch = args.branch
     else:
-        print_info("Using default branchs of the repos")
+        print_info("Using default branches of the repos")
 
     if args.snapshots_build:
         print_info("Using local SNAPSHOT builds for upper level dependencies")
@@ -82,24 +103,29 @@ def main():
         if build_distribution:
             print_info("Building the distribution with the SNAPSHOT versions.")
         if args.commands:
-            print_warn("'--snapshots-build' flag will be overridden by the '--commands' flag")
+            print_warn(
+                "'--snapshots-build' flag will be overridden by the '--commands' flag")
     else:
         print_info("Using existing timestamp versions for the builds")
         if build_distribution:
-            print_warn("Building the distribution, but not using the SNAPSHOT builds")
+            print_warn(
+                "Building the distribution, but not using the SNAPSHOT builds")
 
     if args.publish_to_local_central:
-        print_info("Pushing all the modules to local ballerina central repository")
+        print_info(
+            "Pushing all the modules to local ballerina central repository")
         commands.append("-PpublishToLocalCentral=true")
         if args.commands:
-            print_warn("'--publish-to-local-central' flag will be overridden by the '--commands' flag")
+            print_warn(
+                "'--publish-to-local-central' flag will be overridden by the '--commands' flag")
 
     if args.skip_tests:
         print_info("Skipping tests")
         commands.append("-x")
         commands.append("test")
         if args.commands:
-            print_warn("'--skip-tests' flag will be overridden by the '--commands' flag")
+            print_warn(
+                "'--skip-tests' flag will be overridden by the '--commands' flag")
 
     if args.keep_local_changes:
         print_info("Not updating the local repos.")
@@ -118,38 +144,72 @@ def main():
 
     if args.commands:
         print_info(f'Using custom command: "{args.commands}"')
-        commands = list(filter(None, map(lambda command: command.strip(), args.commands.split(" "))))
+        commands = list(
+            filter(None, map(lambda command: command.strip(), args.commands.split(" "))))
     else:
         print_info(f'Using the command: "{" ".join(commands)}"')
 
+    if args.continue_on_error:
+        print_warn(
+            "Continuing the build even if a module build fails. This may result in build failures in the subsequent modules")
+        continue_on_error = True
+
     if args.skip_modules:
-        skip_modules = list(filter(None, map(lambda module: module.strip(), args.skip_modules.split(","))))
+        skip_modules = list(
+            filter(None, map(lambda module: module.strip(), args.skip_modules.split(","))))
         skipping_word_list = "\",\"".join(skip_modules)
-        print_info(f'Skipping all the modules containing any of the following words: "{skipping_word_list}"')
+        print_info(
+            f'Skipping all the modules containing any of the following words: "{skipping_word_list}"')
+        if use_snapshots:
+            print_warn(
+                f'Skipping modules may result in build failures due to missing dependencies')
 
     module_list = get_stdlib_module_list(build_distribution)
 
-    if args.module:
+    if args.up_to_module:
         if build_distribution:
-            print_error("'--build-distribution' and '--module' flags are mutually exclusive")
-        required_module = get_required_module(args.module, module_list)
+            print_error(
+                "'--build-distribution' and '--module' flags are mutually exclusive")
+        up_to_module = get_required_module(args.up_to_module, module_list)
+        print_info("Building up to the module: " + args.up_to_module)
 
+    if args.from_module:
+        from_module = get_required_module(args.from_module, module_list)
+        print_info("Building from the module: " + args.from_module)
+
+    start_build = False
     for module in module_list:
+        if not start_build and from_module and module[FIELD_NAME] != from_module:
+            continue
+        elif not start_build and from_module and module[FIELD_NAME] == from_module:
+            start_build = True
         if any(map(module[FIELD_NAME].__contains__, skip_modules)):
             module[FIELD_SKIP] = True
         else:
             module[FIELD_SKIP] = False
         module[FIELD_BRANCH] = branch if branch else module[FIELD_DEFAULT_BRANCH]
-        module[FIELD_KEEP_LOCAL_CHANGES] = keep_local_changes
-        process_module(module, commands, lang_version, use_snapshots)
-        if module[FIELD_NAME] == required_module:
-            exit(0)
+        return_code = process_module(module, commands, lang_version,
+                                     use_snapshots, keep_local_changes)
+        if return_code != 0:
+            if continue_on_error:
+                print_error("Build failed for module: " +
+                            module[FIELD_NAME] + ". Continuing the build")
+            else:
+                print_warn("Build failed for module: " +
+                           module[FIELD_NAME] + ". Exiting the build. (Use `--continue-on-error` flag to continue the build even if a module build fails)")
+                break
+
+        if module[FIELD_NAME] == up_to_module:
+            break
+
+    exit(0)
 
 
-def process_module(module, commands, lang_version, use_snapshots):
+def process_module(module, commands, lang_version, use_snapshots, keep_local_changes):
     print_block()
     if module[FIELD_SKIP]:
         print_info("Skipping: " + module[FIELD_NAME])
+        return 0
     else:
         print_info("Processing: " + module[FIELD_NAME])
     print_info("Branch: " + module[FIELD_BRANCH])
@@ -163,18 +223,21 @@ def process_module(module, commands, lang_version, use_snapshots):
 
     os.chdir(module[FIELD_NAME])
 
-    if not module[FIELD_KEEP_LOCAL_CHANGES]:
-        checkout_branch(module[FIELD_BRANCH], module[FIELD_DEFAULT_BRANCH])
+    checkout_branch(module[FIELD_BRANCH], keep_local_changes)
+
+    get_version(module)
 
     if lang_version:
         replace_lang_version(lang_version)
 
     if use_snapshots:
-        replace_stdlibs_version()
+        replace_stdlibs_version(module[FIELD_NAME], use_snapshots)
 
-    subprocess.run(commands)
+    proc = subprocess.run(commands)
 
     os.chdir("..")
+
+    return proc.returncode
 
 
 def replace_lang_version(version):
@@ -187,13 +250,24 @@ def replace_lang_version(version):
     os.replace(TEMP_PROPERTIES, GRADLE_PROPERTIES)
 
 
-def replace_stdlibs_version():
+def replace_stdlibs_version(module_name, snapshots_build):
+    global version_dict
     with open(TEMP_PROPERTIES, "w+") as temp, open(GRADLE_PROPERTIES) as properties:
         for line in properties:
-            if re.match("^stdlib.*Version=", line):
-                version_string = line.split("=")[0]
-                version_number = line.split("=")[1].split("-")[0]
-                line = version_string + "=" + version_number + "-SNAPSHOT" + "\n"
+            if match := re.search("^stdlib(.*)Version=", line):
+                version_name = match.group(1)
+                if version_name in version_dict:
+                    version_string = line.split("=")[0].strip()
+                    version_number = version_dict[version_name].strip()
+                    line = version_string + "=" + version_number + "\n"
+                else:
+                    if snapshots_build:
+                        print_warn(
+                            "Using default snapshot version for: " + match.group(0).replace("=", ""))
+                    version_string = line.split("=")[0].strip()
+                    version_number = line.split("=")[1].split(
+                        "-")[0].strip() + "-SNAPSHOT"
+                    line = version_string + "=" + version_number + "\n"
             temp.write(line)
 
     os.replace(TEMP_PROPERTIES, GRADLE_PROPERTIES)
@@ -208,17 +282,31 @@ def clone_module(module_link):
 def get_required_module(module_name, module_list):
     module_names = [module[FIELD_NAME] for module in module_list]
     if module_name in module_names:
-        print_info("Building up to the module: " + module_name)
         return module_name
     else:
         print_error("Module not found in the list: " + module_name)
+
+
+def get_version(module):
+    global version_dict
+    with open(GRADLE_PROPERTIES) as properties:
+        for line in properties:
+            if re.match("^version=", line):
+                module_name = module[FIELD_NAME].split("-")[-1]
+                if module_name == "jballerina.java.arrays":
+                    module_name = "JavaArrays"
+                elif module_name == "oauth2":
+                    module_name = "OAuth2"
+                else:
+                    module_name = module_name.capitalize()
+                version_dict[module_name] = line.split("=")[1].strip()
 
 
 def checkout_branch(branch, keep_local_changes):
     try:
         subprocess.run(["git", "checkout", branch])
         if not keep_local_changes:
-            subprocess.run(["git", "reset", "--hard", "origin"])
+            subprocess.run(["git", "reset", "--hard", "origin/" + branch])
             subprocess.run(["git", "pull", "origin", branch])
 
     except Exception as e:
@@ -257,13 +345,15 @@ def print_error(message):
     print(f'{Fore.RED}[ERROR] {message}{Style.RESET_ALL}')
     sys.exit(1)
 
+
 def print_warn(message):
-    print(f'{Fore.RED}[WARN] {message}{Style.RESET_ALL}')
+    print(f'{Fore.YELLOW}[WARN] {message}{Style.RESET_ALL}')
 
 
 def print_block():
     print()
     print("##############################################")
     print()
+
 
 main()

--- a/resources/scripts/build_standard_library.py
+++ b/resources/scripts/build_standard_library.py
@@ -190,33 +190,33 @@ def main():
         module[FIELD_BRANCH] = branch if branch else module[FIELD_DEFAULT_BRANCH]
         return_code = process_module(module, commands, lang_version,
                                      use_snapshots, keep_local_changes)
+        exit_code = 0
         if return_code != 0:
+            exit_code = return_code
             if continue_on_error:
-                print_error("Build failed for module: " +
-                            module[FIELD_NAME] + ". Continuing the build")
-            else:
                 print_warn("Build failed for module: " +
-                           module[FIELD_NAME] + ". Exiting the build. (Use `--continue-on-error` flag to continue the build even if a module build fails)")
-                break
+                           module[FIELD_NAME] + ". Continuing the build")
+            else:
+                print_error("Build failed for module: " +
+                            module[FIELD_NAME] + ". Exiting the build. (Use `--continue-on-error` flag to continue the build even if a module build fails)")
 
         if module[FIELD_NAME] == up_to_module:
             break
 
-    exit(0)
+    exit(exit_code)
 
 
 def process_module(module, commands, lang_version, use_snapshots, keep_local_changes):
     print_block()
     if module[FIELD_SKIP]:
         print_info("Skipping: " + module[FIELD_NAME])
-        return 0
     else:
         print_info("Processing: " + module[FIELD_NAME])
     print_info("Branch: " + module[FIELD_BRANCH])
     print_block()
 
     if module[FIELD_SKIP]:
-        return
+        return 0
 
     if not os.path.exists(module[FIELD_NAME]):
         clone_module(module[FIELD_NAME])


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4002

This will improve the Standard Library Build script with the following:

- There was a bug that prevented force-checkout the repositories. It is now fixed.
- When a full build is running, the SNAPSHOT build does not change the version number. It just replace the timestamp version with `SNAPSHOT`. This may cause issues when we build the full standard library using the script.
- Introduce `--from-module` flag: This will help to start the build from a particular module.
- Change the `--module` flag to `--up-to-module` to make the purpose of the flag clear.
- Change the warning color to Yellow from Red.
- Introduce `--continue-on-error` flag and make the default behavior to stop the subsequent builds when a module build is failed. The existing behavior is to continue on error, no matter what.