### PR TITLE
Add additional secrets required to run GraalVM check

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -91,9 +91,9 @@ jobs:
               env:
                   packageUser: ${{ github.actor }}
                   packagePAT: ${{ secrets.GITHUB_TOKEN }}
-                  CLIENT_ID: ${{ secrets.GOOGLESHEETS_CLIENT_ID }}
-                  CLIENT_SECRET: ${{ secrets.GOOGLESHEETS_CLIENT_SECRET }}
-                  REFRESH_TOKEN: ${{ secrets.GOOGLESHEETS_REFRESH_TOKEN }}
+                  CLIENT_ID: ${{ secrets.CLIENT_ID }}
+                  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+                  REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
               run: |
                   perl -pi -e "s/^\s*ballerinaLangVersion=.*/ballerinaLangVersion=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew build -PbalGraalVMTest ${{ inputs.additional_ubuntu_build_flags }}
@@ -175,9 +175,9 @@ jobs:
               env:
                   packageUser: ${{ github.actor }}
                   packagePAT: ${{ secrets.GITHUB_TOKEN }}
-                  CLIENT_ID: ${{ secrets.GOOGLESHEETS_CLIENT_ID }}
-                  CLIENT_SECRET: ${{ secrets.GOOGLESHEETS_CLIENT_SECRET }}
-                  REFRESH_TOKEN: ${{ secrets.GOOGLESHEETS_REFRESH_TOKEN }}
+                  CLIENT_ID: ${{ secrets.CLIENT_ID }}
+                  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+                  REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
               run: |
                   perl -pi -e "s/^\s*ballerinaLangVersion=.*/ballerinaLangVersion=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew.bat build -PbalGraalVMTest ${{ inputs.additional_windows_build_flags }}

--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -175,9 +175,9 @@ jobs:
               env:
                   packageUser: ${{ github.actor }}
                   packagePAT: ${{ secrets.GITHUB_TOKEN }}
-                  CLIENT_ID: ${{ secrets.CLIENT_ID }}
-                  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-                  REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+                  CLIENT_ID: ${{ secrets.GOOGLESHEETS_CLIENT_ID }}
+                  CLIENT_SECRET: ${{ secrets.GOOGLESHEETS_CLIENT_SECRET }}
+                  REFRESH_TOKEN: ${{ secrets.GOOGLESHEETS_REFRESH_TOKEN }}
               run: |
                   perl -pi -e "s/^\s*ballerinaLangVersion=.*/ballerinaLangVersion=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew.bat build -PbalGraalVMTest ${{ inputs.additional_windows_build_flags }}

--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -91,9 +91,9 @@ jobs:
               env:
                   packageUser: ${{ github.actor }}
                   packagePAT: ${{ secrets.GITHUB_TOKEN }}
-                  CLIENT_ID: ${{ secrets.CLIENT_ID }}
-                  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-                  REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+                  CLIENT_ID: ${{ secrets.GOOGLESHEETS_CLIENT_ID }}
+                  CLIENT_SECRET: ${{ secrets.GOOGLESHEETS_CLIENT_SECRET }}
+                  REFRESH_TOKEN: ${{ secrets.GOOGLESHEETS_REFRESH_TOKEN }}
               run: |
                   perl -pi -e "s/^\s*ballerinaLangVersion=.*/ballerinaLangVersion=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew build -PbalGraalVMTest ${{ inputs.additional_ubuntu_build_flags }}

--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -91,6 +91,9 @@ jobs:
               env:
                   packageUser: ${{ github.actor }}
                   packagePAT: ${{ secrets.GITHUB_TOKEN }}
+                  CLIENT_ID: ${{ secrets.CLIENT_ID }}
+                  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+                  REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
               run: |
                   perl -pi -e "s/^\s*ballerinaLangVersion=.*/ballerinaLangVersion=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew build -PbalGraalVMTest ${{ inputs.additional_ubuntu_build_flags }}
@@ -172,6 +175,9 @@ jobs:
               env:
                   packageUser: ${{ github.actor }}
                   packagePAT: ${{ secrets.GITHUB_TOKEN }}
+                  CLIENT_ID: ${{ secrets.CLIENT_ID }}
+                  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+                  REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
               run: |
                   perl -pi -e "s/^\s*ballerinaLangVersion=.*/ballerinaLangVersion=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   ./gradlew.bat build -PbalGraalVMTest ${{ inputs.additional_windows_build_flags }}


### PR DESCRIPTION
## Purpose
> $Subject

Some repositories require other secrets as environment variables to run the build tasks. Since we are running the reusable workflow in the standard library repository we need to add them to the template file. The relevant module repositories will pass their secrets to the workflow using the `secrets: inherit` option.