### PR TITLE
Remove native-image component as explicit input

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -73,7 +73,6 @@ jobs:
               with:
                   java-version: '17'
                   distribution: 'graalvm-community'
-                  components: 'native-image'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   set-java-home: 'false'
 
@@ -158,7 +157,6 @@ jobs:
               with:
                   java-version: '17'
                   distribution: 'graalvm-community'
-                  components: 'native-image'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   set-java-home: 'false'
 


### PR DESCRIPTION
## Purpose

From Java 17, the native-image component is packed with the GraalVM distribution and no need to define it explicitly.
