### PR TITLE
Changed Base image musl

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
@@ -26,13 +26,45 @@ jobs:
         with:
           version: nightly
 
-      - name: Set up GraalVM
+      - name: Check libc configuration
+        id: check_libc
+        run: |
+          if [ -f "ballerina/Ballerina.toml" ]; then
+            if grep -q 'libc.*=.*"musl"' ballerina/Ballerina.toml; then
+              echo "use_musl=true" >> $GITHUB_OUTPUT
+              echo "graalvm_variant=musl" >> $GITHUB_OUTPUT
+              echo "Using musl-based GraalVM configuration"
+            else
+              echo "use_musl=false" >> $GITHUB_OUTPUT
+              echo "graalvm_variant=glibc" >> $GITHUB_OUTPUT
+              echo "Using default glibc-based GraalVM configuration"
+            fi
+          else
+            echo "use_musl=false" >> $GITHUB_OUTPUT
+            echo "graalvm_variant=glibc" >> $GITHUB_OUTPUT
+            echo "Ballerina.toml not found, using default glibc-based GraalVM configuration"
+          fi
+
+      - name: Set up GraalVM (glibc)
+        if: steps.check_libc.outputs.use_musl != 'true'
         uses: graalvm/setup-graalvm@v1
         with:
           java-version: "21"
           distribution: "graalvm-community"
           set-java-home: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up GraalVM (musl)
+        if: steps.check_libc.outputs.use_musl == 'true'
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "21"
+          distribution: "graalvm-community"
+          set-java-home: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          # Configure GraalVM for musl-based builds
+          GRAALVM_MUSL_SUPPORT: true
 
       - name: Check GraalVM installation
         run: |
@@ -53,7 +85,14 @@ jobs:
       - name: Remove Target Directory
         run: sudo rm -rf ballerina/target
 
-      - name: Test with GraalVM
+      - name: Test with GraalVM (glibc)
+        if: steps.check_libc.outputs.use_musl != 'true'
         run: |
           cd ballerina
           bal test --graalvm ${{ inputs.additional-test-flags }}
+
+      - name: Test with GraalVM (musl)
+        if: steps.check_libc.outputs.use_musl == 'true'
+        run: |
+          cd ballerina
+          bal test --graalvm --graalvm-build-options="--libc=musl" ${{ inputs.additional-test-flags }}

--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -86,6 +86,17 @@ jobs:
             - name: Checkout Module Repository
               uses: actions/checkout@v3
 
+            - name: Check libc configuration
+              id: check_libc
+              run: |
+                  if find . -name "Ballerina.toml" -exec grep -l 'libc.*=.*"musl"' {} \; | head -1; then
+                      echo "use_musl=true" >> $GITHUB_OUTPUT
+                      echo "Using musl-based GraalVM configuration"
+                  else
+                      echo "use_musl=false" >> $GITHUB_OUTPUT
+                      echo "Using default glibc-based GraalVM configuration"
+                  fi
+
             - name: Set default native-image options
               if: ${{  inputs.native_image_options != '' }}
               run: |
@@ -101,11 +112,18 @@ jobs:
                   CLIENT_ID: ${{ secrets.CLIENT_ID }}
                   CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
                   REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+                  BAL_GRAALVM_LIBC: ${{ steps.check_libc.outputs.use_musl == 'true' && 'musl' || 'glibc' }}
               run: |
                   if ${{ github.event_name != 'pull_request' }}; then
                       perl -pi -e "s/^\s*ballerinaLangVersion=.*/ballerinaLangVersion=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   fi
-                  ./gradlew build -PbalGraalVMTest ${{ inputs.additional_ubuntu_build_flags }}
+                  if [[ "${{ steps.check_libc.outputs.use_musl }}" == "true" ]]; then
+                      echo "Building with musl libc support"
+                      ./gradlew build -PbalGraalVMTest -PgraalvmLibc=musl ${{ inputs.additional_ubuntu_build_flags }}
+                  else
+                      echo "Building with default glibc support"
+                      ./gradlew build -PbalGraalVMTest ${{ inputs.additional_ubuntu_build_flags }}
+                  fi
 
     windows-build-with-bal-test-graalvm:
         name: Build with bal test graalvm on Windows
@@ -177,6 +195,18 @@ jobs:
             - name: Checkout Module Repository
               uses: actions/checkout@v3
 
+            - name: Check libc configuration
+              id: check_libc_windows
+              run: |
+                  $found = Get-ChildItem -Recurse -Name "Ballerina.toml" | Where-Object { (Get-Content $_) -match 'libc.*=.*"musl"' }
+                  if ($found) {
+                      "use_musl=true" >> $env:GITHUB_OUTPUT
+                      Write-Output "Using musl-based GraalVM configuration"
+                  } else {
+                      "use_musl=false" >> $env:GITHUB_OUTPUT
+                      Write-Output "Using default glibc-based GraalVM configuration"
+                  }
+
             - name: Set default native-image options
               if: ${{  inputs.native_image_options != '' }}
               run: |
@@ -200,8 +230,15 @@ jobs:
                   CLIENT_ID: ${{ secrets.CLIENT_ID }}
                   CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
                   REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+                  BAL_GRAALVM_LIBC: ${{ steps.check_libc_windows.outputs.use_musl == 'true' && 'musl' || 'glibc' }}
               run: |
                   if (${{ github.event_name != 'pull_request' }}) {
                       perl -pi -e "s/^\s*version=.*/version=${{ env.BALLERINA_LANG_VERSION }}/" gradle.properties
                   }
-                  ./gradlew.bat build -PbalGraalVMTest ${{ inputs.additional_windows_build_flags }}
+                  if ("${{ steps.check_libc_windows.outputs.use_musl }}" -eq "true") {
+                      Write-Output "Building with musl libc support"
+                      ./gradlew.bat build -PbalGraalVMTest -PgraalvmLibc=musl ${{ inputs.additional_windows_build_flags }}
+                  } else {
+                      Write-Output "Building with default glibc support"
+                      ./gradlew.bat build -PbalGraalVMTest ${{ inputs.additional_windows_build_flags }}
+                  }

--- a/docs/graalvm-compatibility-in-ballerina-libraries.md
+++ b/docs/graalvm-compatibility-in-ballerina-libraries.md
@@ -226,3 +226,14 @@ If you get GraalVM compatibility warnings when building or packing the library, 
 [platform.java21]
 graalvmCompatible = true
 ```
+
+### Configure libc for GraalVM native builds
+
+When building GraalVM native images, you can specify the libc implementation to use. By default, the build uses glibc. To use musl libc (which results in smaller, statically linked binaries suitable for Alpine Linux containers), add the following to the `Ballerina.toml`:
+
+```toml
+[build-options]
+libc = "musl"
+```
+
+When `libc = "musl"` is specified, the build system will automatically use a musl-based base image for the GraalVM native build, resulting in binaries that are compatible with Alpine Linux and other musl-based distributions.

--- a/library-templates/generated-connector-template/files/README.md
+++ b/library-templates/generated-connector-template/files/README.md
@@ -98,6 +98,17 @@ Execute the commands below to build from the source.
    ./gradlew clean build -PpublishToCentral=true
    ```
 
+### GraalVM Native Image Options
+
+For building native executables using GraalVM, you can configure the libc implementation in the `Ballerina.toml` file:
+
+```toml
+[build-options]
+libc = "musl"
+```
+
+When `libc = "musl"` is set, the build will use musl-based images for GraalVM native compilation, resulting in smaller binaries compatible with Alpine Linux and other musl-based distributions. If not specified, the default glibc implementation is used.
+
 ## Contribute to Ballerina
 
 As an open-source project, Ballerina welcomes contributions from the community.

--- a/library-templates/generated-connector-template/files/ballerina/Ballerina.toml
+++ b/library-templates/generated-connector-template/files/ballerina/Ballerina.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/ballerina-platform/{{REPO_NAME}}"
 
 [build-options]
 observabilityIncluded = true
+# libc = "musl" # Remove to use musl-based base image for GraalVM native builds
 
 [platform.java21]
 graalvmCompatible = true

--- a/library-templates/generated-connector-template/files/build-config/resources/Ballerina.toml
+++ b/library-templates/generated-connector-template/files/build-config/resources/Ballerina.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/ballerina-platform/{{REPO_NAME}}"
 
 [build-options]
 observabilityIncluded = true
+# libc = "musl" # Remove Comment to use musl-based base image for GraalVM native builds
 
 [platform.java21]
 graalvmCompatible = true


### PR DESCRIPTION
Resolves #7122 

## Purpose
This change makes building Ballerina projects easier by automatically switching to a musl-based base image whenever --libc=musl is set in Ballerina.toml

## Goals
The goal is to simplify the build process by detecting the libc setting automatically and picking the right base image

## User stories
This change allows developers to automatically use a musl-based base image by simply setting --libc=musl in Ballerina.toml

## Release note
Builds now automatically switch to a musl-based base image when --libc=musl is specified in Ballerina.toml