### PR TITLE
Fix: Return modified modules list in build_standard_library.py

### DIFF
--- a/resources/scripts/build_standard_library.py
+++ b/resources/scripts/build_standard_library.py
@@ -365,7 +365,7 @@ def get_stdlib_module_list(build_distribution, build_extended_modules, build_con
         print("append tools")
         if build_tools:
             modules = modules + module_list["tools"]
-        return module_list["modules"]
+        return modules
     except Exception as e:
         print("Failed to read the module list JSON file: " + str(e))
         sys.exit()


### PR DESCRIPTION
## Description

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8347

Fixes a logic bug in `get_stdlib_module_list()` function where the modified `modules` list was not being returned.

## Problem
The function was building a modified `modules` list throughout its execution (adding extended_modules, connectors, tools, and distribution when requested), but was returning the original unmodified `module_list["modules"]` instead.

This caused command-line flags to be ignored:
- `--build-extended-modules`
- `--build-connectors` 
- `--build-tools`
- `--build-distribution`

## Solution
Changed line 368 in `resources/scripts/build_standard_library.py`:
- **Before:** `return module_list["modules"]`
- **After:** `return modules`

## Impact
Users can now successfully build extended modules, connectors, tools, and distribution when using the respective command-line flags.

## Testing
- [x] Verified the logic fix addresses the root cause
- [x] No breaking changes introduced
- [x] Code follows project standards

## Related
- Identified during security audit/code review
- This is a functional bug fix that improves build script reliability

---
**Note:** This is a Hacktoberfest contribution 🎃

**Checklist:**
- [x] Code follows the project's coding standards
- [x] Fix addresses the root cause of the issue
- [x] No breaking changes introduced