### PR TITLE
Push the branch before creating the PR for publish workflow

### DIFF
--- a/.github/workflows/release-package-connector-template.yml
+++ b/.github/workflows/release-package-connector-template.yml
@@ -112,4 +112,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           gh release create v$VERSION --title "module-${{ inputs.package-org }}-${{ inputs.package-name }}-v$VERSION"
+          git push origin release-${VERSION}
           gh pr create --base ${GITHUB_REF##*/} --title "[Automated] Sync ${GITHUB_REF##*/} after $VERSION release" --body "Sync ${GITHUB_REF##*/} after $VERSION release"

--- a/.github/workflows/release-package-template.yml
+++ b/.github/workflows/release-package-template.yml
@@ -100,4 +100,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           gh release create v$VERSION --title "module-${{ inputs.package-org }}-${{ inputs.package-name }}-v$VERSION"
+          git push origin release-${VERSION}
           gh pr create --base ${GITHUB_REF##*/} --title "[Automated] Sync ${GITHUB_REF##*/} after $VERSION release" --body "Sync ${GITHUB_REF##*/} after $VERSION release"


### PR DESCRIPTION
## Purpose

> $Subject

With the latest GitHub CLI, the branch need to be explicitly pushed first or the `gh pr create` command should explicitly have the `head` parameter. Otherwise we will get the following error and the workflow will fail:

```
aborted: you must first push the current branch to a remote, or use the --head flag
```

Example failure: https://github.com/ballerina-platform/module-ballerina-http/actions/runs/19886697517/job/56995395160

As a fix, explicitly pushing the branch before creating the PR