### PR TITLE
Add dynamic Ballerina version resolution step

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
@@ -21,10 +21,22 @@ jobs:
       - name: Checkout the Repository
         uses: actions/checkout@v3
 
+      - name: Resolve Ballerina version
+        run: |
+          BAL_VERSION="nightly"
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            EXTRACTED="$(grep -E '^\s*ballerinaLangVersion\s*=' gradle.properties | head -n 1 | cut -d= -f2- | xargs || true)"
+            if [[ -n "${EXTRACTED}" ]]; then
+              BAL_VERSION="${EXTRACTED}"
+            fi
+          fi
+          echo "BAL_VERSION=${BAL_VERSION}" >> "$GITHUB_ENV"
+          echo "Resolved BAL_VERSION: ${BAL_VERSION}"
+
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
-          version: nightly
+          version: ${{ env.BAL_VERSION }}
 
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1


### PR DESCRIPTION
## Description

> $Subject

Added a step to resolve the Ballerina version dynamically based on the gradle.properties file.

This is already supported in library workflow template(https://github.com/ballerina-platform/ballerina-library/pull/7849). Adding the same support for connector workflow template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request adds dynamic Ballerina version resolution to the GraalVM connector build workflow template, replacing hardcoded version values with a configurable approach.

## Changes

A new workflow step "Resolve Ballerina version" is introduced that:
- Defaults to the "nightly" Ballerina version
- Reads the `ballerinaLangVersion` property from `gradle.properties` for non-pull request events to determine the exact version to use
- Exports the resolved version to the workflow environment as `BAL_VERSION`

The subsequent "Set Up Ballerina" step now uses this dynamically resolved `BAL_VERSION` environment variable instead of a hardcoded value.

## Impact

This change brings parity with the existing version resolution support in the library workflow template, enabling:
- Consistent version management across workflow templates
- Flexibility to pin specific Ballerina versions through the project's build configuration
- Automatic version detection without manual workflow updates

The change is minimal (13 lines added, 1 removed) and maintains backward compatibility with a sensible default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->