### PR TITLE
Fix condition for Ballerina version resolution

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-connector-template.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Resolve Ballerina version
         run: |
           BAL_VERSION="nightly"
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             EXTRACTED="$(grep -E '^\s*ballerinaLangVersion\s*=' gradle.properties | head -n 1 | cut -d= -f2- | xargs || true)"
             if [[ -n "${EXTRACTED}" ]]; then
               BAL_VERSION="${EXTRACTED}"


### PR DESCRIPTION
> $Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resolve Ballerina Version Condition

This pull request fixes the condition logic in the "Resolve Ballerina version" step of the GraalVM connector build workflow. The change corrects when the Ballerina version should be extracted from `gradle.properties` versus defaulting to a nightly build.

**Key Change:**
The conditional check now properly extracts the Ballerina version from `gradle.properties` when the workflow is triggered by a pull request event. For other trigger events (such as scheduled builds or manual dispatches), the workflow defaults to using the nightly version.

This ensures that pull request builds use the version specified in the project configuration, while non-PR builds continue to use the latest nightly version for development and integration testing. This improves workflow stability by aligning version resolution with the appropriate build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->