### PR TITLE
Add XLSX to the library module list

### DIFF
--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -104,6 +104,9 @@
             "name": "module-ballerina-random"
         },
         {
+            "name": "module-ballerina-smb"
+        },
+        {
             "name": "module-ballerina-soap"
         },
         {

--- a/release/resources/module_list.json
+++ b/release/resources/module_list.json
@@ -143,6 +143,9 @@
             "name": "module-ballerina-websubhub"
         },
         {
+            "name": "module-ballerina-xlsx"
+        },
+        {
             "name": "module-ballerina-xmldata"
         },
         {


### PR DESCRIPTION
Register module-ballerina-xlsx under library_modules so it appears on the Status Dashboard and is included in the library release pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates the library module registry to include additional modules in the Ballerina library ecosystem. Specifically, it adds `module-ballerina-smb` and `module-ballerina-xlsx` to the `library_modules` list so both modules appear on the Status Dashboard and are picked up by the library release pipeline.

## Changes

- **release/resources/module_list.json**
  - Added `module-ballerina-smb` to `library_modules` (inserted after `module-ballerina-random` and before `module-ballerina-soap`)
  - Added `module-ballerina-xlsx` to `library_modules` (inserted after `module-ballerina-websubhub` and before `module-ballerina-xmldata`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->