### PR TITLE
Fix broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We appreciate your help!
 ## Get started
 
 - Download [Ballerina](https://ballerina.io/downloads/) and go through the [learning resources](https://ballerina.io/learn/).
-- Read the [Ballerina Code of Conduct]("https://ballerina.io/code-of-conduct").
+- Read the [Ballerina Code of Conduct](https://ballerina.io/code-of-conduct).
 - Join the [Ballerina community](https://ballerina.io/community/).
 - Submitting a bug is just as important as contributing to code. [Report an issue](https://github.com/ballerina-platform/ballerina-standard-library/issues).
 - Start with GitHub issues that can be fixed easily:

--- a/docs/adding-a-new-ballerina-module.md
+++ b/docs/adding-a-new-ballerina-module.md
@@ -435,7 +435,7 @@ This field defines the name of the module. This should be the name of the reposi
 
 The version key of the module. This is related to the version prefix mentioned in the [`gradle.properties`](#the-gradleproperties-file-required) file. (e.g., `ballerinaStdlibIo`). It is used to add the module as a dependency to another repository including the [`ballerina-distribution`](https://github.com/ballerina-platform/ballerina-distribution) repository.
 
-Refer the [`version_key`](#the-version_key-field) section under [Add the module to the Ballerina library](#add-the-module-to-the-ballerina-library-optional).
+Refer the [`version_key`](#the-version_key-field) section under [Add the module to the Ballerina library](#add-the-module-to-the-ballerina-library-required).
 
 #### The `group_id` JSON field
 


### PR DESCRIPTION
## Purpose
Two documentation links in the repository are broken. This PR fixes both.

1. In `docs/adding-a-new-ballerina-module.md`, an internal anchor points to `#add-the-module-to-the-ballerina-library-optional`, but the target heading is `### Add the module to the Ballerina library [Required]`, which renders as the anchor `-required`. The link is dead, and the table of contents already uses the correct `-required` anchor.
2. In `CONTRIBUTING.md`, the Code of Conduct link has quotation marks inside the URL - `("https://ballerina.io/code-of-conduct")` - which breaks the Markdown link. The same link appears correctly (unquoted) in `README.md`.

No existing issue - documentation only fix

## Goals
Fix both broken links so the in-page navigation and the Code of Conduct link work correctly.

## Approach
- `docs/adding-a-new-ballerina-module.md`: changed the anchor from `-optional` to `-required` to match the actual heading (and the existing TOC entry).
- `CONTRIBUTING.md`: removed the stray quotation marks from inside the link URL.

## User stories
N/A

## Release note
Fixed two broken documentation links

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A - documentation change only
 - Integration tests
   > N/A - documentation change only

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A - no code changes.
- Ran FindSecurityBugs plugin and verified report? N/A - no code changes.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated two documentation links to point to the correct destinations: fixed the Ballerina Code of Conduct link in `CONTRIBUTING.md` and corrected the internal anchor in `docs/adding-a-new-ballerina-module.md` so it matches the referenced section. This is a documentation-only change with no code impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->