### PR TITLE
Declare explicit secrets for reusable workflows and connector template

### DIFF
--- a/.github/workflows/build-connector-template.yml
+++ b/.github/workflows/build-connector-template.yml
@@ -18,6 +18,13 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      CODECOV_TOKEN:
+        required: false
 
 
 jobs:

--- a/.github/workflows/build-timestamp-master-template.yml
+++ b/.github/workflows/build-timestamp-master-template.yml
@@ -7,6 +7,13 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/build-with-bal-test-graalvm-template.yml
+++ b/.github/workflows/build-with-bal-test-graalvm-template.yml
@@ -30,6 +30,13 @@ on:
                 required: false
                 type: string
                 default: ''
+        secrets:
+            CLIENT_ID:
+                required: false
+            CLIENT_SECRET:
+                required: false
+            REFRESH_TOKEN:
+                required: false
 
 jobs:
     ubuntu-build-with-bal-test-graalvm:

--- a/.github/workflows/central-publish-template.yml
+++ b/.github/workflows/central-publish-template.yml
@@ -14,6 +14,15 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      BALLERINA_CENTRAL_DEV_ACCESS_TOKEN:
+        required: true
+      BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN:
+        required: true
 
 jobs:
   publish-release:

--- a/.github/workflows/daily-build-connector-template.yml
+++ b/.github/workflows/daily-build-connector-template.yml
@@ -14,6 +14,9 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
 
 jobs:
   ubuntu-build:

--- a/.github/workflows/dev-stage-central-publish-connector-template.yml
+++ b/.github/workflows/dev-stage-central-publish-connector-template.yml
@@ -10,6 +10,15 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      BALLERINA_CENTRAL_DEV_ACCESS_TOKEN:
+        required: true
+      BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN:
+        required: true
 
 jobs:
   publish-release:

--- a/.github/workflows/pr-build-connector-template.yml
+++ b/.github/workflows/pr-build-connector-template.yml
@@ -11,6 +11,9 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
     ubuntu-build:

--- a/.github/workflows/pull-request-build-template.yml
+++ b/.github/workflows/pull-request-build-template.yml
@@ -19,6 +19,9 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 
 # The `build` and `test` commands ran separately as the Ballerina Gradle plugin does not support skipping test groups

--- a/.github/workflows/regenerate-connector-template.yml
+++ b/.github/workflows/regenerate-connector-template.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_REVIEWER_BOT_TOKEN:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/release-package-connector-template.yml
+++ b/.github/workflows/release-package-connector-template.yml
@@ -21,6 +21,15 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      BALLERINA_BOT_EMAIL:
+        required: true
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      BALLERINA_CENTRAL_ACCESS_TOKEN:
+        required: true
 
 jobs:
   publish-release:

--- a/.github/workflows/release-package-template.yml
+++ b/.github/workflows/release-package-template.yml
@@ -17,6 +17,15 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      BALLERINA_BOT_EMAIL:
+        required: true
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      BALLERINA_CENTRAL_ACCESS_TOKEN:
+        required: true
 
 jobs:
   publish-release:

--- a/.github/workflows/s4hana-build-connector-template.yml
+++ b/.github/workflows/s4hana-build-connector-template.yml
@@ -6,6 +6,9 @@ on:
       hana-connector-group:
         required: true
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   build-examples:

--- a/.github/workflows/s4hana-daily-build-connector-template.yml
+++ b/.github/workflows/s4hana-daily-build-connector-template.yml
@@ -6,6 +6,9 @@ on:
       hana-connector-group:
         required: true
         type: string
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
 
 jobs:
   build-examples:

--- a/.github/workflows/s4hana-dev-stage-central-publish-template.yml
+++ b/.github/workflows/s4hana-dev-stage-central-publish-template.yml
@@ -9,6 +9,15 @@ on:
       hana-connector-group:
         required: true
         type: string
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      BALLERINA_CENTRAL_DEV_ACCESS_TOKEN:
+        required: true
+      BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN:
+        required: true
 
 jobs:
   generate-matrix:

--- a/.github/workflows/s4hana-dev-stage-central-single-publish-template.yml
+++ b/.github/workflows/s4hana-dev-stage-central-single-publish-template.yml
@@ -12,6 +12,15 @@ on:
       hana-connector-name:
         required: true
         type: string
+    secrets:
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      BALLERINA_CENTRAL_DEV_ACCESS_TOKEN:
+        required: true
+      BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN:
+        required: true
 
 jobs:
   publish-release:

--- a/.github/workflows/s4hana-pr-template.yml
+++ b/.github/workflows/s4hana-pr-template.yml
@@ -6,6 +6,9 @@ on:
       hana-connector-group:
         required: true
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   generate-matrix:

--- a/.github/workflows/s4hana-release-template.yml
+++ b/.github/workflows/s4hana-release-template.yml
@@ -9,6 +9,15 @@ on:
       hana-connector-name:
         required: true
         type: string
+    secrets:
+      BALLERINA_BOT_EMAIL:
+        required: true
+      BALLERINA_BOT_TOKEN:
+        required: true
+      BALLERINA_BOT_USERNAME:
+        required: true
+      BALLERINA_CENTRAL_ACCESS_TOKEN:
+        required: true
 
 jobs:
   call_workflow:

--- a/library-templates/generated-connector-template/files/.github/workflows/auto-generate.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/auto-generate.yml
@@ -33,7 +33,9 @@ jobs:
     name: Run Auto-Generate Connector Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/auto_generate_connector_template.yml@connector-automation
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
     with:
       openapi-url: ${{ inputs.openapi-url }}
       ballerina-version: ${{ inputs.ballerina-version }}

--- a/library-templates/generated-connector-template/files/.github/workflows/build-with-bal-test-graalvm.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/build-with-bal-test-graalvm.yml
@@ -1,0 +1,17 @@
+name: GraalVM Check
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  call_workflow:
+    name: Run GraalVM Build Workflow
+    if: ${{ github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-connector-template.yml@main

--- a/library-templates/generated-connector-template/files/.github/workflows/ci.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     name: Run Connector Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/build-connector-template.yml@main
-    secrets: inherit
+    secrets:
+      BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+      BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       repo-name: {{REPO_NAME}}

--- a/library-templates/generated-connector-template/files/.github/workflows/daily-build.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/daily-build.yml
@@ -1,0 +1,15 @@
+name: Daily build
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+
+jobs:
+  call_workflow:
+    name: Run Daily Build Workflow
+    if: ${{ github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/daily-build-connector-template.yml@main
+    secrets:
+      BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+    with:
+      repo-name: {{REPO_NAME}}

--- a/library-templates/generated-connector-template/files/.github/workflows/dev-stg-release.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/dev-stg-release.yml
@@ -16,6 +16,10 @@ jobs:
     name: Run Dev\Stage Central Publish Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/dev-stage-central-publish-connector-template.yml@main
-    secrets: inherit
+    secrets:
+      BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+      BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
+      BALLERINA_CENTRAL_DEV_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+      BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
     with:
       environment: ${{ github.event.inputs.environment }}

--- a/library-templates/generated-connector-template/files/.github/workflows/pull-request.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/pull-request.yml
@@ -11,6 +11,7 @@ jobs:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pr-build-connector-template.yml@main
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       additional-test-flags: ${{ github.event.pull_request.head.repo.full_name != github.repository && '-x test' || ''}}

--- a/library-templates/generated-connector-template/files/.github/workflows/release.yml
+++ b/library-templates/generated-connector-template/files/.github/workflows/release.yml
@@ -10,7 +10,11 @@ jobs:
     name: Run Release Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/release-package-connector-template.yml@main
-    secrets: inherit
+    secrets:
+      BALLERINA_BOT_EMAIL: ${{ secrets.BALLERINA_BOT_EMAIL }}
+      BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+      BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
+      BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
     with:
       package-name: {{MODULE_NAME_CC}}
       package-org: ballerinax


### PR DESCRIPTION
## Summary

- Add `secrets:` declarations under `on.workflow_call` to the reusable workflow templates in
  `.github/workflows/` that read secrets directly in their steps, so callers can pass named
  secrets instead of `secrets: inherit`.
- Update the generated connector template's caller files to pass only the secrets each workflow
  actually needs, instead of `secrets: inherit`.
- Add the two caller files (`build-with-bal-test-graalvm.yml`, `daily-build.yml`) that generated
  connector repos already carry today but this template was missing, with the same fix applied.

`GITHUB_TOKEN` is intentionally excluded everywhere — it's minted automatically per job regardless
of `secrets: inherit`/explicit passing, so it never needs to be declared or threaded through.

## Out of scope for this PR

The `uses:` ref (`@main` / `@connector-automation`) is left unchanged here. Pinning to an immutable
ref is a separate, larger decision still under discussion and isn't part of this change.

This also doesn't touch any downstream repo yet — those will be updated in a follow-up batch to
stop using `secrets: inherit` once this merges.

Part of #8926


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added explicit secret contracts to reusable workflow templates, distinguishing required and optional inputs.
- Updated generated connector workflows to pass only the secrets each reusable workflow needs instead of inheriting all secrets.
- Added missing GraalVM test and daily-build caller workflows.
- Kept `GITHUB_TOKEN` excluded because it is provided automatically per job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->