### PR TITLE
Align the generating connectors skill with the connector-tool regeneration workflow

### DIFF
--- a/agent-skills/.claude-plugin/plugin.json
+++ b/agent-skills/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ballerina-libdev",
   "displayName": "Ballerina Library Skills",
   "description": "Agent skills for developing and maintaining Ballerina library modules.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "WSO2",
     "url": "https://wso2.com"

--- a/agent-skills/.claude-plugin/plugin.json
+++ b/agent-skills/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ballerina-libdev",
   "displayName": "Ballerina Library Skills",
   "description": "Agent skills for developing and maintaining Ballerina library modules.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "WSO2",
     "url": "https://wso2.com"

--- a/agent-skills/skills/generating-connectors/SKILL.md
+++ b/agent-skills/skills/generating-connectors/SKILL.md
@@ -160,7 +160,7 @@ All scripts are in `<skill-root>/scripts/` and are pure Python (`.py`) — no sh
 <PYTHON_CMD> scripts/generate_mock_stub.py "<aligned-spec>" "<output-dir>" "<SELECTED_OPERATIONS>" "<LICENSE_PATH>"
 
 # Run any bal command in a working directory — prints stderr to a temp file and its path on failure
-<PYTHON_CMD> scripts/run_bal_command.py "<command>" "<working-dir>"
+<PYTHON_CMD> scripts/run_bal_command.py --cwd "<working-dir>" <command> [<argument>...]
 
 # Parse compilation errors from bal build stderr → JSON error array
 <PYTHON_CMD> scripts/parse_errors.py "<stderr-file-or-stdin>"

--- a/agent-skills/skills/generating-connectors/SKILL.md
+++ b/agent-skills/skills/generating-connectors/SKILL.md
@@ -46,7 +46,7 @@ When this skill is invoked:
    ```
    ╔══════════════════════════════════════════╗
    ║       Ballerina Connector Generator      ║
-   ╚══════════════════════════════════════════╝
+   ╚════════════════════════════════ ᵥ₀․₂․₀ ══╝
 
    I'll guide you through generating a Ballerina connector from your OpenAPI spec.
    This involves up to 5 stages: sanitize → client → tests → examples → docs.

--- a/agent-skills/skills/generating-connectors/SKILL.md
+++ b/agent-skills/skills/generating-connectors/SKILL.md
@@ -33,7 +33,7 @@ Scripts in `scripts/` handle all deterministic operations. Run them via Bash —
 | 1. Sanitize | `stages/01-sanitize.md` | Yes (`sanitize`) | `aligned_ballerina_openapi.yaml`, `sanitations.md` |
 | 2. Client | `stages/02-client.md` | Yes (`client`) | `client.bal`, `types.bal` — build + auto-fix inline |
 | 3. Tests | `stages/03-tests.md` | Yes (`tests`) | `tests/test.bal`, mock server — build + auto-fix inline |
-| 4. Examples | `stages/04-examples.md` | Yes (`examples`) | per-example packages in `examples/` — build + auto-fix inline |
+| 4. Examples | `stages/04-examples.md` | Yes (`examples`) | regenerate safely, or retain + validate existing packages when excluded |
 | 5. Docs | `stages/05-docs.md` | Yes (`docs`) | `README.md`, `Module.md`, Ballerina.toml keywords |
 
 ---
@@ -62,6 +62,8 @@ When this skill is invoked:
        Read the corresponding stage file
        Follow its instructions completely
        If INTERACTIVE_MODE: pause and confirm before next stage
+     elif stage == examples:
+       Read `stages/04-examples.md` and follow its retained-example validation path
    ```
 
 4. When any stage runs `bal build` and it fails, read `references/fix-procedure.md` and invoke it immediately in that stage's context before proceeding.
@@ -77,8 +79,8 @@ These variables are set in Setup (stage 00) and used by all subsequent stages:
 | `PYTHON_CMD` | Resolved Python 3 command for this machine (`python3`/`python`/`py`) — determined once in Setup Step 0 |
 | `SPEC_PATH` | Absolute or relative path to the input OpenAPI spec |
 | `BALLERINA_DIR` | Directory containing (or to contain) `Ballerina.toml` — where `client.bal`, `types.bal`, `utils.bal`, `tests/`, `README.md`, `Module.md` are generated |
-| `SPEC_DIR` | User-confirmed path for aligned spec + sanitations (default: `./docs/spec`) |
-| `EXAMPLE_DIR` | User-confirmed path for generated examples (default: `./examples`) — unset if the `examples` stage is excluded |
+| `SPEC_DIR` | User-confirmed path for aligned spec, `sanitations.md`, and `ai-mappings.json` (default: `./docs/spec`) |
+| `EXAMPLE_DIR` | User-confirmed path for generated examples (default: `./examples`); retained examples use this default even when generation is excluded |
 | `BAL_ORG` | Ballerina package org (read from Ballerina.toml or collected from user) |
 | `BAL_PACKAGE` | Ballerina package name (read from Ballerina.toml or collected from user) |
 | `LICENSE_PATH` | Path to the user-provided license file, or empty if not provided |
@@ -171,4 +173,15 @@ All scripts are in `<skill-root>/scripts/` and are pure Python (`.py`) — no sh
 
 # Scan an aligned spec for duplicate operationIds — non-fatal warnings
 <PYTHON_CMD> scripts/check_duplicate_operation_ids.py "<aligned-spec>"
+
+# Reuse and persist stable AI schema-name decisions across regeneration runs
+<PYTHON_CMD> scripts/schema_mappings.py prepare "<aligned-spec>" "<ai-mappings.json>" "<candidate.json>"
+<PYTHON_CMD> scripts/schema_mappings.py apply "<aligned-spec>" "<candidate.json>" "<decisions.json>" "<ai-mappings.json>"
+
+# Capture and compare client/types source snapshots for semantic-version advice
+<PYTHON_CMD> scripts/client_version_summary.py capture "<ballerina-dir>" "<baseline.json>"
+<PYTHON_CMD> scripts/client_version_summary.py diff "<ballerina-dir>" "<baseline.json>"
+
+# Scan or safely clean generated example packages only
+<PYTHON_CMD> scripts/manage_examples.py <scan|cleanup> "<examples-dir>"
 ```

--- a/agent-skills/skills/generating-connectors/references/fix-procedure.md
+++ b/agent-skills/skills/generating-connectors/references/fix-procedure.md
@@ -47,7 +47,7 @@ Use the Edit tool to apply each fix at the specific file and line.
 #### 2c. Re-run build
 
 ```bash
-<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal build" "<BUILD_DIR>"
+<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py --cwd "<BUILD_DIR>" bal build
 ```
 
 - Exit 0 → build clean, exit loop, report success

--- a/agent-skills/skills/generating-connectors/references/workflows.md
+++ b/agent-skills/skills/generating-connectors/references/workflows.md
@@ -93,28 +93,32 @@ At the end of the pipeline (or when aborted), print:
 ```
 === Generating Ballerina Connectors — Run Summary ===
 Spec:         <input spec path>
-Output:       <output dir>
+Output:       <BALLERINA_DIR>
 Stages run:   sanitize ✓  client ✓  tests ✓  examples ✓  docs ✓
 Stages skipped: (none)
 
 Generated files:
-  docs/spec/aligned_ballerina_openapi.json
-  docs/spec/ai-mappings.json
-  docs/spec/sanitations.md
-  client.bal
-  types.bal
-  tests/mock_service.bal
-  tests/test.bal
-  examples/<example-name>/main.bal
-  examples/<example-name>/Ballerina.toml
-  examples/<example-name>/<example-name>.md
-  examples/README.md
-  README.md
-  Module.md
+  <SPEC_DIR>/aligned_ballerina_openapi.json          # sanitize completed
+  <SPEC_DIR>/ai-mappings.json                        # sanitize completed
+  <SPEC_DIR>/sanitations.md                          # sanitize completed
+  <BALLERINA_DIR>/client.bal                         # client completed
+  <BALLERINA_DIR>/types.bal                          # client completed
+  <BALLERINA_DIR>/utils.bal                          # client completed, if generated
+  <BALLERINA_DIR>/tests/mock_service.bal             # tests completed
+  <BALLERINA_DIR>/tests/test.bal                     # tests completed
+  <EXAMPLE_DIR>/<example-name>/main.bal              # examples completed
+  <EXAMPLE_DIR>/<example-name>/Ballerina.toml        # examples completed
+  <EXAMPLE_DIR>/<example-name>/<example-name>.md     # docs completed; documented examples only
+  <EXAMPLE_DIR>/README.md                            # docs completed
+  <BALLERINA_DIR>/README.md                          # docs completed
+  <BALLERINA_DIR>/Module.md                          # docs completed
+  <BALLERINA_DIR>/tests/README.md                    # docs completed
 
 Next steps:
-  1. Review docs/spec/sanitations.md for the structural spec changes (from flatten/align).
-  2. Run `bal test` to verify the generated tests.
-  3. Navigate into examples/<example-name> and run `bal run` to try an example.
+  1. Review <SPEC_DIR>/sanitations.md for the structural spec changes (from flatten/align).
+  2. Run `bal test` from <BALLERINA_DIR> to verify the generated tests.
+  3. Navigate into <EXAMPLE_DIR>/<example-name> and run `bal run` to try an example.
   4. Publish to Ballerina Central when ready.
 ```
+
+Replace the illustrative stage statuses with the actual completed and skipped stages. List a generated-file entry only when the stage named in its comment completed; omit files that were not produced (including `utils.bal` when absent and example documents that failed generation). List the corresponding Next steps only when their prerequisite stage completed.

--- a/agent-skills/skills/generating-connectors/references/workflows.md
+++ b/agent-skills/skills/generating-connectors/references/workflows.md
@@ -18,7 +18,7 @@ Stages run in this fixed order. Each stage may be skipped if the user excluded i
 ```
 
 Skip validation rules (mirror the connector-tool's `OpenApiStageValidationUtils`):
-- If `sanitize` is skipped: `<SPEC_DIR>/aligned_ballerina_openapi.yaml` must exist — fail with a clear message if not.
+- If `sanitize` is skipped: `<SPEC_DIR>/aligned_ballerina_openapi.json` must exist — fail with a clear message if not.
 - If `client` is skipped: `<BALLERINA_DIR>/client.bal` must exist — fail with a clear message if not.
 - If all stages are skipped: reject immediately.
 

--- a/agent-skills/skills/generating-connectors/references/workflows.md
+++ b/agent-skills/skills/generating-connectors/references/workflows.md
@@ -13,7 +13,7 @@ Stages run in this fixed order. Each stage may be skipped if the user excluded i
 1. sanitize   → skippable; requires aligned spec to exist if skipped
 2. client     → skippable; requires client.bal to exist if skipped; runs fix procedure inline on build failure
 3. tests      → skippable; runs fix procedure inline on build failure
-4. examples   → skippable; runs fix procedure inline per example on build failure (non-fatal if fix fails)
+4. examples   → safely cleans recognized generated packages before regeneration; when excluded, its retained-example validation path still runs; runs fix procedure inline per example (non-fatal if fix fails)
 5. docs       → skippable
 ```
 
@@ -73,7 +73,7 @@ When `--interactive` is enabled:
 → Invoke fix procedure with `BUILD_DIR = EXAMPLE_DIR/<example-name>`. If exhausted, warn and continue to the next example — non-fatal.
 
 ### `bal test` failure
-→ Non-fatal. Record and continue. Note failure in the final summary.
+→ Run the bounded test-only repair loop on `tests/test.bal` and `tests/mock_service.bal`. Stop on pass, unchanged diagnostics, no applicable edit, or the iteration limit. Record unresolved failures and continue.
 
 ---
 
@@ -99,6 +99,7 @@ Stages skipped: (none)
 
 Generated files:
   docs/spec/aligned_ballerina_openapi.json
+  docs/spec/ai-mappings.json
   docs/spec/sanitations.md
   client.bal
   types.bal
@@ -106,6 +107,7 @@ Generated files:
   tests/test.bal
   examples/<example-name>/main.bal
   examples/<example-name>/Ballerina.toml
+  examples/<example-name>/<example-name>.md
   examples/README.md
   README.md
   Module.md

--- a/agent-skills/skills/generating-connectors/scripts/client_version_summary.py
+++ b/agent-skills/skills/generating-connectors/scripts/client_version_summary.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Capture and compare the generated client API without relying on Git.
+
+Usage:
+  client_version_summary.py capture <ballerina-dir> <baseline.json>
+  client_version_summary.py diff <ballerina-dir> <baseline.json>
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+
+def atomic_write(path: str, data: dict) -> None:
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=".connector-client-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            json.dump(data, file, indent=2)
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+    except OSError:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def read_snapshot(path: Path) -> dict:
+    if not path.is_file():
+        return {"exists": False, "content": ""}
+    return {"exists": True, "content": path.read_text(encoding="utf-8")}
+
+
+def meaningful(content: str) -> bool:
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    content = re.sub(r"(?m)^\s*(?://|#).*?$", "", content)
+    return bool(content.strip())
+
+
+def capture(directory: str, output: str) -> None:
+    root = Path(directory)
+    client = read_snapshot(root / "client.bal")
+    atomic_write(output, {
+        "client": client,
+        "types": read_snapshot(root / "types.bal"),
+        "has_meaningful_client": client["exists"] and meaningful(client["content"]),
+    })
+    print(json.dumps({"baseline_path": output, "has_meaningful_client": client["exists"] and meaningful(client["content"])}))
+
+
+def package_version(directory: Path) -> str:
+    toml = directory / "Ballerina.toml"
+    if not toml.is_file():
+        return ""
+    package = re.search(r"^\[package\](.*?)(?=^\[|\Z)", toml.read_text(encoding="utf-8"), re.MULTILINE | re.DOTALL)
+    match = re.search(r'^version\s*=\s*"([^"]+)"', package.group(1), re.MULTILINE) if package else None
+    return match.group(1) if match else ""
+
+
+def diff(directory: str, baseline_path: str) -> None:
+    baseline = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
+    root = Path(directory)
+    if not baseline.get("has_meaningful_client"):
+        print(json.dumps({"skipped": "no meaningful previous client.bal", "diff": "", "version": package_version(root)}))
+        return
+    chunks = []
+    for name, key in (("client.bal", "client"), ("types.bal", "types")):
+        before = (baseline.get(key) or {}).get("content", "").replace("\r\n", "\n").replace("\r", "\n")
+        after = read_snapshot(root / name)["content"].replace("\r\n", "\n").replace("\r", "\n")
+        if before != after:
+            chunks.append("Changes in " + name + ":\n" + "\n".join(difflib.unified_diff(
+                before.splitlines(), after.splitlines(), fromfile="previous/" + name, tofile="current/" + name,
+                lineterm="")))
+    print(json.dumps({"skipped": "" if chunks else "no client/types changes", "diff": "\n\n".join(chunks), "version": package_version(root)}))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 4 and sys.argv[1] == "capture":
+        capture(sys.argv[2], sys.argv[3])
+    elif len(sys.argv) == 4 and sys.argv[1] == "diff":
+        diff(sys.argv[2], sys.argv[3])
+    else:
+        print(f"Usage: {sys.argv[0]} capture <ballerina-dir> <baseline.json>", file=sys.stderr)
+        print(f"       {sys.argv[0]} diff <ballerina-dir> <baseline.json>", file=sys.stderr)
+        raise SystemExit(2)

--- a/agent-skills/skills/generating-connectors/scripts/manage_examples.py
+++ b/agent-skills/skills/generating-connectors/scripts/manage_examples.py
@@ -11,6 +11,7 @@ import json
 import shutil
 import sys
 from pathlib import Path
+from uuid import uuid4
 
 
 def examples(root: Path) -> list[Path]:
@@ -27,12 +28,55 @@ def scan(root: Path) -> None:
 
 def cleanup(root: Path) -> None:
     removed, failures = [], []
-    for item in examples(root):
+    found = examples(root)
+    if not found:
+        print(json.dumps({"removed": removed, "failures": failures, "complete": True}))
+        raise SystemExit(0)
+
+    quarantine = root / f".generated-examples-quarantine-{uuid4().hex}"
+    moved: list[tuple[Path, Path]] = []
+
+    def restore() -> None:
+        for original, quarantined in reversed(moved):
+            if not quarantined.exists():
+                if not original.exists():
+                    removed.append(original.name)
+                    failures.append(f"{quarantined}: cannot restore; package was deleted")
+                continue
+            try:
+                quarantined.rename(original)
+            except OSError as exc:
+                failures.append(f"{quarantined}: restore failed: {exc}")
         try:
-            shutil.rmtree(item)
-            removed.append(item.name)
+            quarantine.rmdir()
         except OSError as exc:
-            failures.append(f"{item}: {exc}")
+            if quarantine.exists():
+                failures.append(f"{quarantine}: cleanup failed: {exc}")
+
+    try:
+        quarantine.mkdir()
+    except OSError as exc:
+        failures.append(f"{quarantine}: {exc}")
+    else:
+        for item in found:
+            try:
+                quarantined = quarantine / item.name
+                item.rename(quarantined)
+                moved.append((item, quarantined))
+            except OSError as exc:
+                failures.append(f"{item}: {exc}")
+                restore()
+                break
+
+        if not failures:
+            try:
+                shutil.rmtree(quarantine)
+            except OSError as exc:
+                failures.append(f"{quarantine}: {exc}")
+                restore()
+            else:
+                removed = [item.name for item in found]
+
     print(json.dumps({"removed": removed, "failures": failures, "complete": not failures}))
     raise SystemExit(0 if not failures else 1)
 

--- a/agent-skills/skills/generating-connectors/scripts/manage_examples.py
+++ b/agent-skills/skills/generating-connectors/scripts/manage_examples.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Safely identify and clean generated example packages.
+
+Only immediate subdirectories containing both main.bal and Ballerina.toml are
+considered generated use-case examples. Other user content is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def examples(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return sorted([entry for entry in root.iterdir() if entry.is_dir() and
+                   (entry / "main.bal").is_file() and (entry / "Ballerina.toml").is_file()], key=lambda item: item.name)
+
+
+def scan(root: Path) -> None:
+    found = examples(root)
+    print(json.dumps({"examples": [item.name for item in found], "count": len(found)}))
+
+
+def cleanup(root: Path) -> None:
+    removed, failures = [], []
+    for item in examples(root):
+        try:
+            shutil.rmtree(item)
+            removed.append(item.name)
+        except OSError as exc:
+            failures.append(f"{item}: {exc}")
+    print(json.dumps({"removed": removed, "failures": failures, "complete": not failures}))
+    raise SystemExit(0 if not failures else 1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3 or sys.argv[1] not in {"scan", "cleanup"}:
+        print(f"Usage: {sys.argv[0]} <scan|cleanup> <examples-dir>", file=sys.stderr)
+        raise SystemExit(2)
+    (scan if sys.argv[1] == "scan" else cleanup)(Path(sys.argv[2]))

--- a/agent-skills/skills/generating-connectors/scripts/manage_examples.py
+++ b/agent-skills/skills/generating-connectors/scripts/manage_examples.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from uuid import uuid4
 
 
+QUARANTINE_PREFIX = ".generated-examples-quarantine-"
+
+
 def examples(root: Path) -> list[Path]:
     if not root.is_dir():
         return []
@@ -21,32 +24,76 @@ def examples(root: Path) -> list[Path]:
                    (entry / "main.bal").is_file() and (entry / "Ballerina.toml").is_file()], key=lambda item: item.name)
 
 
+def quarantines(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return sorted([entry for entry in root.iterdir() if entry.is_dir() and entry.name.startswith(QUARANTINE_PREFIX)],
+                  key=lambda item: item.name)
+
+
+def reconcile_quarantines(root: Path) -> list[str]:
+    failures = []
+    for quarantine in quarantines(root):
+        for item in examples(quarantine):
+            original = root / item.name
+            if original.exists():
+                failures.append(f"{item}: cannot restore; {original} already exists")
+                continue
+            try:
+                item.rename(original)
+            except OSError as exc:
+                failures.append(f"{item}: restore failed: {exc}")
+        try:
+            quarantine.rmdir()
+        except OSError as exc:
+            if quarantine.exists():
+                failures.append(f"{quarantine}: cleanup failed: {exc}")
+    return failures
+
+
 def scan(root: Path) -> None:
+    failures = reconcile_quarantines(root)
     found = examples(root)
-    print(json.dumps({"examples": [item.name for item in found], "count": len(found)}))
+    result = {"examples": [item.name for item in found], "count": len(found)}
+    if failures:
+        result.update({"failures": failures, "complete": False})
+    print(json.dumps(result))
+    if failures:
+        raise SystemExit(1)
 
 
 def cleanup(root: Path) -> None:
     removed, failures = [], []
+    failures.extend(reconcile_quarantines(root))
+    if failures:
+        print(json.dumps({"removed": removed, "failures": failures, "complete": False}))
+        raise SystemExit(1)
+
     found = examples(root)
     if not found:
         print(json.dumps({"removed": removed, "failures": failures, "complete": True}))
         raise SystemExit(0)
 
-    quarantine = root / f".generated-examples-quarantine-{uuid4().hex}"
+    quarantine = root / f"{QUARANTINE_PREFIX}{uuid4().hex}"
     moved: list[tuple[Path, Path]] = []
+
+    def record_removed(name: str) -> None:
+        if name not in removed:
+            removed.append(name)
 
     def restore() -> None:
         for original, quarantined in reversed(moved):
             if not quarantined.exists():
                 if not original.exists():
-                    removed.append(original.name)
+                    record_removed(original.name)
                     failures.append(f"{quarantined}: cannot restore; package was deleted")
                 continue
             try:
                 quarantined.rename(original)
             except OSError as exc:
                 failures.append(f"{quarantined}: restore failed: {exc}")
+                if quarantined.exists() and not original.exists():
+                    record_removed(original.name)
         try:
             quarantine.rmdir()
         except OSError as exc:

--- a/agent-skills/skills/generating-connectors/scripts/restore_prior_operation_ids.py
+++ b/agent-skills/skills/generating-connectors/scripts/restore_prior_operation_ids.py
@@ -27,8 +27,27 @@ from __future__ import annotations
 import sys
 import json
 import os
+import tempfile
 
 HTTP_METHODS = ("get", "post", "put", "patch", "delete", "head", "options", "trace")
+
+
+def atomic_write_json(path: str, value: dict) -> None:
+    directory = os.path.dirname(os.path.abspath(path))
+    fd, temporary = tempfile.mkstemp(prefix=".connector-operation-ids-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(value, f, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temporary, path)
+    except OSError:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
 
 
 def build_prior_operation_id_map(spec: dict) -> dict[str, dict[str, str]]:
@@ -104,8 +123,7 @@ def cmd_apply(map_file_path: str, current_spec_path: str) -> dict:
                 reserved_ids.append(operation_id)
 
     if restored:
-        with open(current_spec_path, "w", encoding="utf-8") as f:
-            json.dump(current_spec, f, indent=2)
+        atomic_write_json(current_spec_path, current_spec)
 
     return {
         "prior_spec_found": prior_spec_found,

--- a/agent-skills/skills/generating-connectors/scripts/run_bal_command.py
+++ b/agent-skills/skills/generating-connectors/scripts/run_bal_command.py
@@ -2,13 +2,12 @@
 """
 Wrapper for Ballerina CLI commands.
 
-Usage: run_bal_command.py "<full command>" [<working-dir>]
+Usage: run_bal_command.py [--cwd <working-dir>] <command> [<argument>...]
 Prints stdout/stderr to terminal and exits with the command's exit code.
 On failure, also writes captured stderr to a temp file and prints its path.
 """
 
 import os
-import shlex
 import subprocess
 import sys
 import tempfile
@@ -17,21 +16,27 @@ DEFAULT_TIMEOUT_SECONDS = 1800
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
-        print('Usage: run_bal_command.py "<command>" [<working-dir>]', file=sys.stderr)
+    arguments = sys.argv[1:]
+    workdir = os.getcwd()
+    if arguments[:1] == ["--cwd"]:
+        if len(arguments) < 3:
+            print("Usage: run_bal_command.py [--cwd <working-dir>] <command> [<argument>...]", file=sys.stderr)
+            sys.exit(2)
+        workdir = arguments[1]
+        arguments = arguments[2:]
+
+    if not arguments:
+        print("Usage: run_bal_command.py [--cwd <working-dir>] <command> [<argument>...]", file=sys.stderr)
         sys.exit(2)
 
-    command = sys.argv[1]
-    workdir = sys.argv[2] if len(sys.argv) > 2 else os.getcwd()
+    command = arguments
 
     os.makedirs(workdir, exist_ok=True)
 
-    print(f">>> Running: {command}")
+    print(f">>> Running: {subprocess.list2cmdline(command)}")
     print(f">>> Working dir: {workdir}")
     print("")
     sys.stdout.flush()
-
-    args = shlex.split(command, posix=(os.name != "nt"))
 
     try:
         timeout_seconds = int(os.environ.get("CONNECTOR_BAL_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
@@ -41,16 +46,17 @@ def main() -> None:
         print("ERROR: CONNECTOR_BAL_TIMEOUT_SECONDS must be a positive integer.", file=sys.stderr)
         sys.exit(2)
     try:
-        if os.name == "nt":
-            result = subprocess.run(command, shell=True, cwd=workdir, capture_output=True, text=True,
-                                    timeout=timeout_seconds)
-        else:
-            result = subprocess.run(args, shell=False, cwd=workdir, capture_output=True, text=True,
-                                    timeout=timeout_seconds)
+        result = subprocess.run(command, shell=False, cwd=workdir, capture_output=True, text=True,
+                                timeout=timeout_seconds)
     except subprocess.TimeoutExpired as exc:
-        stdout = exc.stdout or ""
-        stderr = (exc.stderr or "") + f"\nCommand timed out after {timeout_seconds} seconds."
-        result = subprocess.CompletedProcess(args, 124, stdout, stderr)
+        def text_output(value):
+            if isinstance(value, bytes):
+                return value.decode("utf-8", errors="replace")
+            return value or ""
+
+        stdout = text_output(exc.stdout)
+        stderr = text_output(exc.stderr) + f"\nCommand timed out after {timeout_seconds} seconds."
+        result = subprocess.CompletedProcess(command, 124, stdout, stderr)
 
     if result.stdout:
         print(result.stdout, end="")

--- a/agent-skills/skills/generating-connectors/scripts/run_bal_command.py
+++ b/agent-skills/skills/generating-connectors/scripts/run_bal_command.py
@@ -13,6 +13,8 @@ import subprocess
 import sys
 import tempfile
 
+DEFAULT_TIMEOUT_SECONDS = 1800
+
 
 def main() -> None:
     if len(sys.argv) < 2:
@@ -31,10 +33,24 @@ def main() -> None:
 
     args = shlex.split(command, posix=(os.name != "nt"))
 
-    if os.name == "nt":
-        result = subprocess.run(command, shell=True, cwd=workdir, capture_output=True, text=True)
-    else:
-        result = subprocess.run(args, shell=False, cwd=workdir, capture_output=True, text=True)
+    try:
+        timeout_seconds = int(os.environ.get("CONNECTOR_BAL_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+        if timeout_seconds <= 0:
+            raise ValueError
+    except ValueError:
+        print("ERROR: CONNECTOR_BAL_TIMEOUT_SECONDS must be a positive integer.", file=sys.stderr)
+        sys.exit(2)
+    try:
+        if os.name == "nt":
+            result = subprocess.run(command, shell=True, cwd=workdir, capture_output=True, text=True,
+                                    timeout=timeout_seconds)
+        else:
+            result = subprocess.run(args, shell=False, cwd=workdir, capture_output=True, text=True,
+                                    timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = (exc.stderr or "") + f"\nCommand timed out after {timeout_seconds} seconds."
+        result = subprocess.CompletedProcess(args, 124, stdout, stderr)
 
     if result.stdout:
         print(result.stdout, end="")

--- a/agent-skills/skills/generating-connectors/scripts/schema_mappings.py
+++ b/agent-skills/skills/generating-connectors/scripts/schema_mappings.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Maintain stable OpenAPI component-schema names across regeneration runs.
+
+Usage:
+  schema_mappings.py prepare <aligned-spec.json> <ai-mappings.json> <candidate.json>
+  schema_mappings.py apply <aligned-spec.json> <candidate.json> <decisions.json> <ai-mappings.json>
+
+``prepare`` applies the reusable decisions from ``ai-mappings.json`` to the
+current aligned spec, prunes mappings for schemas that no longer exist, and
+prints schema metadata that still needs an AI decision. ``apply`` validates
+the supplied decisions, applies every rename (including local $refs), and
+persists the merged mapping document atomically. Unknown top-level mapping
+sections are intentionally preserved.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_json(path: str, default: Any = None) -> Any:
+    if not os.path.exists(path):
+        return default
+    try:
+        with open(path, encoding="utf-8") as file:
+            return json.load(file)
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"could not read JSON file {path}: {exc}")
+
+
+def atomic_write_json(path: str, value: Any) -> None:
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".connector-schema-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump(value, file, indent=2, ensure_ascii=False)
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+    except OSError as exc:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        fail(f"could not atomically write {path}: {exc}")
+
+
+def schemas(spec: dict[str, Any]) -> dict[str, Any]:
+    components = spec.get("components")
+    if not isinstance(components, dict) or not isinstance(components.get("schemas"), dict):
+        fail("aligned specification has no components.schemas mapping")
+    return components["schemas"]
+
+
+def schema_metadata(name: str, schema: Any) -> dict[str, Any]:
+    schema = schema if isinstance(schema, dict) else {}
+    return {
+        "name": name,
+        "type": schema.get("type", "object"),
+        "description": (schema.get("description") or "")[:200],
+        "properties": list((schema.get("properties") or {}).keys())[:10],
+    }
+
+
+def is_valid_name(name: Any) -> bool:
+    return isinstance(name, str) and bool(name.strip()) and not any(c in name for c in ("/", "#", "\n", "\r"))
+
+
+def rewrite_refs(value: Any, renames: dict[str, str]) -> Any:
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if key == "$ref" and isinstance(item, str) and item.startswith("#/components/schemas/"):
+                source = item.rsplit("/", 1)[1]
+                result[key] = "#/components/schemas/" + renames.get(source, source)
+            else:
+                result[key] = rewrite_refs(item, renames)
+        return result
+    if isinstance(value, list):
+        return [rewrite_refs(item, renames) for item in value]
+    return value
+
+
+def apply_renames(spec: dict[str, Any], renames: dict[str, str]) -> None:
+    current = schemas(spec)
+    active = {source: target for source, target in renames.items() if source in current and source != target}
+    targets = list(active.values())
+    if len(targets) != len(set(targets)):
+        fail("schema mapping has duplicate target names")
+    untouched = set(current) - set(active)
+    collisions = sorted(set(targets) & untouched)
+    if collisions:
+        fail("schema mapping target collides with current schema: " + ", ".join(collisions))
+    renamed = {active.get(name, name): value for name, value in current.items()}
+    spec["components"]["schemas"] = renamed
+    rewritten = rewrite_refs(spec, active)
+    spec.clear()
+    spec.update(rewritten)
+
+
+def load_mapping_document(path: str) -> dict[str, Any]:
+    document = read_json(path, {})
+    if not isinstance(document, dict):
+        fail("ai-mappings.json must contain a JSON object")
+    mappings = document.get("schemaNames", {})
+    if not isinstance(mappings, dict) or not all(is_valid_name(k) and is_valid_name(v) for k, v in mappings.items()):
+        fail("ai-mappings.json schemaNames must be a string-to-string mapping")
+    return document
+
+
+def prepare(spec_path: str, mappings_path: str, candidate_path: str) -> None:
+    spec = read_json(spec_path)
+    if not isinstance(spec, dict):
+        fail("aligned specification must contain a JSON object")
+    document = load_mapping_document(mappings_path)
+    current = schemas(spec)
+    original_names = set(current)
+    stored = document.get("schemaNames", {})
+    reusable = {source: target for source, target in stored.items() if source in original_names}
+    pruned = sorted(set(stored) - original_names)
+    if reusable:
+        apply_renames(spec, reusable)
+        atomic_write_json(spec_path, spec)
+    mapped_sources = set(reusable)
+    # New schemas are identified from the pre-rename names, so a target name is
+    # never accidentally treated as a new source schema on reruns.
+    unseen = [schema_metadata(name, current[name]) for name in sorted(original_names - mapped_sources)]
+    candidate = dict(document)
+    candidate["schemaNames"] = reusable
+    atomic_write_json(candidate_path, candidate)
+    print(json.dumps({
+        "reused_count": len(reusable),
+        "pruned_count": len(pruned),
+        "pruned_schema_names": pruned,
+        "unseen_schemas": unseen,
+        "candidate_path": str(Path(candidate_path)),
+    }))
+
+
+def apply(spec_path: str, candidate_path: str, decisions_path: str, output_path: str) -> None:
+    spec = read_json(spec_path)
+    candidate = load_mapping_document(candidate_path)
+    decisions = read_json(decisions_path)
+    if not isinstance(spec, dict) or not isinstance(decisions, dict):
+        fail("spec and decisions must be JSON objects")
+    current = schemas(spec)
+    existing = candidate.get("schemaNames", {})
+    unknown = set(current) - set(existing.values())
+    supplied = set(decisions)
+    missing = sorted(unknown - supplied)
+    extra = sorted(supplied - unknown)
+    if missing or extra:
+        fail("schema decisions must cover exactly the unseen schemas" +
+             (f"; missing: {', '.join(missing)}" if missing else "") +
+             (f"; unexpected: {', '.join(extra)}" if extra else ""))
+    if not all(is_valid_name(source) and is_valid_name(target) for source, target in decisions.items()):
+        fail("schema decisions must use non-empty, path-safe names")
+    targets = list(existing.values()) + list(decisions.values())
+    if len(targets) != len(set(targets)):
+        fail("schema decisions contain a duplicate or reserved target name")
+    all_mappings = {**existing, **decisions}
+    apply_renames(spec, decisions)
+    candidate["schemaNames"] = all_mappings
+    atomic_write_json(spec_path, spec)
+    atomic_write_json(output_path, candidate)
+    print(json.dumps({"applied_count": len(decisions), "identity_count": sum(k == v for k, v in decisions.items())}))
+
+
+def usage() -> None:
+    print(f"Usage: {sys.argv[0]} prepare <aligned-spec.json> <ai-mappings.json> <candidate.json>", file=sys.stderr)
+    print(f"       {sys.argv[0]} apply <aligned-spec.json> <candidate.json> <decisions.json> <ai-mappings.json>", file=sys.stderr)
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 5 and sys.argv[1] == "prepare":
+        prepare(*sys.argv[2:])
+    elif len(sys.argv) == 6 and sys.argv[1] == "apply":
+        apply(*sys.argv[2:])
+    else:
+        usage()

--- a/agent-skills/skills/generating-connectors/stages/00-setup.md
+++ b/agent-skills/skills/generating-connectors/stages/00-setup.md
@@ -190,7 +190,7 @@ Store as `SPEC_DIR`.
 
 ## Step 6: Example directory
 
-Skip this step entirely if `examples` is in `EXCLUDED_STAGES` — leave `EXAMPLE_DIR` unset.
+If `examples` is in `EXCLUDED_STAGES`, set `EXAMPLE_DIR = ./examples` without prompting. This is the connector-tool default and lets the excluded-stage path retain and validate existing generated examples. Otherwise ask:
 
 "2+1" prompt (connector-tool default is `./examples`):
 

--- a/agent-skills/skills/generating-connectors/stages/01-sanitize.md
+++ b/agent-skills/skills/generating-connectors/stages/01-sanitize.md
@@ -122,7 +122,17 @@ From `ALIGNED_SPEC_METADATA`, note:
 
 Using `ALIGNED_SPEC_METADATA` (not the raw spec), review and improve each category below. Each sub-step applies its own changes directly to `ALIGNED_SPEC` and writes the file back before moving to the next — operationId improvement, schema renaming, description enhancement, and summary improvement are each self-contained, matching how connector-tool treats them as separate read-modify-write passes rather than one deferred bulk write.
 
-### 3a. OperationId improvement (two-pass)
+When a category has enough items to require multiple AI requests, process deterministic batches. If every batch fails, stop sanitation without claiming success. If only some batches fail, preserve successful changes, print the failed batch identifiers, and continue with a partial-failure warning.
+
+### 3a. Short or missing descriptions
+
+For schema fields, parameters, and operations where `description` is fewer than 10 characters (or empty), generate a concise description from the structured aligned metadata and apply it directly to `ALIGNED_SPEC`.
+
+### 3b. Operation summary improvement
+
+For operations where `summary` is fewer than 10 characters (or empty), generate a concise summary from the path, method, and parameter names. Apply it directly to `ALIGNED_SPEC` before improving operationIds.
+
+### 3c. OperationId improvement (two-pass)
 
 **Pass A — restore from previous run.** This step is fully deterministic — do not reason through it manually, run the script:
 
@@ -164,14 +174,30 @@ The map file has now been fully consumed — delete it:
 
 Print any `WARNING: duplicate operationId ...` lines verbatim. Non-fatal — record the warning and continue (client generation will also surface any remaining conflicts).
 
-### 3b. Generic schema names
-If schema names like `Object`, `Response`, `InlineResponse200`, `Item`, `Body` appear, propose better names based on context (the operation that returns/consumes them). Apply renames consistently, then write `ALIGNED_SPEC` back before continuing.
+### 3d. Stable schema names
 
-### 3c. Short or missing descriptions
-For schema fields, parameters, and operations where `description` is fewer than 10 characters (or empty), generate a concise description from context (field/parameter name, or the operation's path, method, and parameters). Apply directly to `ALIGNED_SPEC` and write back.
+Schema-name decisions are persisted in `<SPEC_DIR>/ai-mappings.json`; it is a regeneration artifact and may contain unrelated top-level sections that must be preserved. Do not hand-edit the aligned JSON or mapping file.
 
-### 3d. Operation summary improvement
-For operations where `summary` is fewer than 10 characters (or empty), generate a concise summary from the path, method, and parameter names — this becomes the doc comment on the generated client's resource/remote function. Apply directly to `ALIGNED_SPEC` and write back.
+First prepare the current run and apply reusable decisions:
+
+```bash
+<PYTHON_CMD> <skill-root>/scripts/schema_mappings.py prepare \
+  "<ALIGNED_SPEC>" "<SPEC_DIR>/ai-mappings.json" "<SPEC_DIR>/.schema_mappings_candidate.json"
+```
+
+Read the returned `unseen_schemas` JSON only. On the first run this contains every schema. On later runs it contains only newly introduced schemas; prior decisions have already been applied, including every local `#/components/schemas/...` reference.
+
+For every unseen schema, ask AI for one concise, unique public schema name based on its structured metadata. Require a JSON object mapping every source name to its target name. Preserve an already good name as an identity mapping. Never include prose or code fences.
+
+Validate the response by writing it to `<SPEC_DIR>/.schema_name_decisions.json` and apply it:
+
+```bash
+<PYTHON_CMD> <skill-root>/scripts/schema_mappings.py apply \
+  "<ALIGNED_SPEC>" "<SPEC_DIR>/.schema_mappings_candidate.json" \
+  "<SPEC_DIR>/.schema_name_decisions.json" "<SPEC_DIR>/ai-mappings.json"
+```
+
+If validation rejects malformed, incomplete, or colliding names, retry the AI response up to the normal bounded retry limit. For any remaining schema, use an identity mapping (`"OriginalName": "OriginalName"`) and re-run `apply`; print a warning. The script atomically persists the spec and mappings, prunes mappings for removed schemas, and preserves unknown top-level mapping data. Delete the two transient dot-files after a successful apply.
 
 ---
 
@@ -206,7 +232,7 @@ Print:
 ✓ Sanitize complete
   Aligned spec: <SPEC_DIR>/aligned_ballerina_openapi.json
   Sanitations:  <SPEC_DIR>/sanitations.md (structural spec changes: <SANITATION_COUNTS>)
-  AI enhancements applied: <N> operationIds improved (<R> restored from previous run), <K> schemas renamed, <M> descriptions enhanced, <S> summaries improved
+  AI enhancements applied: <M> descriptions enhanced, <S> summaries improved, <N> operationIds improved (<R> restored), <K> schema decisions (<U> reused, <I> identity fallbacks, <P> pruned)
 ```
 
 The AI enhancements line reports the Step 3 work applied to the spec — those are intentionally not part of `sanitations.md`, which holds only the structural diff.

--- a/agent-skills/skills/generating-connectors/stages/01-sanitize.md
+++ b/agent-skills/skills/generating-connectors/stages/01-sanitize.md
@@ -59,8 +59,8 @@ This extracts just the `path -> {method: operationId}` map (not a full spec copy
 
 ```bash
 <PYTHON_CMD> <skill-root>/scripts/run_bal_command.py \
-  "bal openapi flatten -i <SPEC_PATH> -o <SPEC_DIR>" \
-  "<BALLERINA_DIR>"
+  --cwd "<BALLERINA_DIR>" \
+  bal openapi flatten -i "<SPEC_PATH>" -o "<SPEC_DIR>"
 ```
 
 Output: `<SPEC_DIR>/flattened_openapi.yaml` (or similar — capture the actual filename from stdout).
@@ -75,8 +75,8 @@ Use the flattened file path captured from Step 1's stdout as input to align. Do 
 
 ```bash
 <PYTHON_CMD> <skill-root>/scripts/run_bal_command.py \
-  "bal openapi align -i <flattened-path> -o <SPEC_DIR>" \
-  "<BALLERINA_DIR>"
+  --cwd "<BALLERINA_DIR>" \
+  bal openapi align -i "<flattened-path>" -o "<SPEC_DIR>"
 ```
 
 If this fails, print the error and ask the user to resolve it before continuing.
@@ -185,9 +185,9 @@ First prepare the current run and apply reusable decisions:
   "<ALIGNED_SPEC>" "<SPEC_DIR>/ai-mappings.json" "<SPEC_DIR>/.schema_mappings_candidate.json"
 ```
 
-Read the returned `unseen_schemas` JSON only. On the first run this contains every schema. On later runs it contains only newly introduced schemas; prior decisions have already been applied, including every local `#/components/schemas/...` reference.
+Parse the returned JSON and store `UNSEEN_SCHEMAS` from `unseen_schemas`, `REUSED_SCHEMA_COUNT` from `reused_count`, and `PRUNED_SCHEMA_COUNT` from `pruned_count`. On the first run `UNSEEN_SCHEMAS` contains every schema. On later runs it contains only newly introduced schemas; prior decisions have already been applied, including every local `#/components/schemas/...` reference. Only `UNSEEN_SCHEMAS` is input to schema decisions.
 
-For every unseen schema, ask AI for one concise, unique public schema name based on its structured metadata. Require a JSON object mapping every source name to its target name. Preserve an already good name as an identity mapping. Never include prose or code fences.
+For every schema in `UNSEEN_SCHEMAS`, ask AI for one concise, unique public schema name based on its structured metadata. Require a JSON object mapping every source name to its target name. Preserve an already good name as an identity mapping. Never include prose or code fences.
 
 Validate the response by writing it to `<SPEC_DIR>/.schema_name_decisions.json` and apply it:
 
@@ -197,7 +197,7 @@ Validate the response by writing it to `<SPEC_DIR>/.schema_name_decisions.json` 
   "<SPEC_DIR>/.schema_name_decisions.json" "<SPEC_DIR>/ai-mappings.json"
 ```
 
-If validation rejects malformed, incomplete, or colliding names, retry the AI response up to the normal bounded retry limit. For any remaining schema, use an identity mapping (`"OriginalName": "OriginalName"`) and re-run `apply`; print a warning. The script atomically persists the spec and mappings, prunes mappings for removed schemas, and preserves unknown top-level mapping data. Delete the two transient dot-files after a successful apply.
+Parse the successful `apply` result and store `SCHEMA_DECISION_COUNT` from `applied_count` and `IDENTITY_SCHEMA_COUNT` from `identity_count`. If validation rejects malformed, incomplete, or colliding names, retry the AI response up to the normal bounded retry limit. For any remaining schema, use an identity mapping (`"OriginalName": "OriginalName"`) and re-run `apply`; print a warning. The script atomically persists the spec and mappings, prunes mappings for removed schemas, and preserves unknown top-level mapping data. Delete the two transient dot-files after a successful apply.
 
 ---
 
@@ -232,7 +232,7 @@ Print:
 ✓ Sanitize complete
   Aligned spec: <SPEC_DIR>/aligned_ballerina_openapi.json
   Sanitations:  <SPEC_DIR>/sanitations.md (structural spec changes: <SANITATION_COUNTS>)
-  AI enhancements applied: <M> descriptions enhanced, <S> summaries improved, <N> operationIds improved (<R> restored), <K> schema decisions (<U> reused, <I> identity fallbacks, <P> pruned)
+  AI enhancements applied: <M> descriptions enhanced, <S> summaries improved, <N> operationIds improved (<R> restored), <SCHEMA_DECISION_COUNT> schema decisions (<REUSED_SCHEMA_COUNT> reused, <IDENTITY_SCHEMA_COUNT> identity fallbacks, <PRUNED_SCHEMA_COUNT> pruned)
 ```
 
 The AI enhancements line reports the Step 3 work applied to the spec — those are intentionally not part of `sanitations.md`, which holds only the structural diff.

--- a/agent-skills/skills/generating-connectors/stages/02-client.md
+++ b/agent-skills/skills/generating-connectors/stages/02-client.md
@@ -51,11 +51,11 @@ Append options based on collected configuration:
 
 ```bash
 <PYTHON_CMD> <skill-root>/scripts/run_bal_command.py \
-  "bal openapi -i '<ALIGNED_SPEC>' -o '<BALLERINA_DIR>' --license '<LICENSE_PATH>' [--tags <tags>] [--operations <ops>] [--client-methods remote] --mode client" \
-  "<BALLERINA_DIR>"
+  --cwd "<BALLERINA_DIR>" \
+  bal openapi -i "<ALIGNED_SPEC>" -o "<BALLERINA_DIR>" --mode client
 ```
 
-Omit `--license <LICENSE_PATH>` if `LICENSE_PATH` is not set. Omit any other optional flag that does not apply.
+Append each applicable option as separate arguments: `--license "<LICENSE_PATH>"`, one `--tags "<tag>"` pair per tag, one `--operations "<id>"` pair per operation ID, and `--client-methods remote` when `USE_REMOTE` is true. Omit every optional flag/value pair that does not apply.
 
 ### On success:
 Verify that `<BALLERINA_DIR>/client.bal`, `<BALLERINA_DIR>/types.bal`, and `<BALLERINA_DIR>/utils.bal` were created. Print the file list.
@@ -72,7 +72,7 @@ Verify that `<BALLERINA_DIR>/client.bal`, `<BALLERINA_DIR>/types.bal`, and `<BAL
 Run `bal build` in `<BALLERINA_DIR>`:
 
 ```bash
-<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal build" "<BALLERINA_DIR>"
+<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py --cwd "<BALLERINA_DIR>" bal build
 ```
 
 - Exit 0 → build clean, continue to completion

--- a/agent-skills/skills/generating-connectors/stages/02-client.md
+++ b/agent-skills/skills/generating-connectors/stages/02-client.md
@@ -7,6 +7,19 @@ If skipped, verify that `<BALLERINA_DIR>/client.bal` already exists — halt if 
 
 ---
 
+## Step 0: Capture the client baseline
+
+Before generation, capture source snapshots without using Git:
+
+```bash
+<PYTHON_CMD> <skill-root>/scripts/client_version_summary.py capture \
+  "<BALLERINA_DIR>" "<BALLERINA_DIR>/.client_version_baseline.json"
+```
+
+Keep this transient baseline until Step 4. A missing, empty, or comment-only previous `client.bal` means version analysis is skipped.
+
+---
+
 ## Step 1: Build the `bal openapi` command
 
 Resolve the spec input file:
@@ -38,7 +51,7 @@ Append options based on collected configuration:
 
 ```bash
 <PYTHON_CMD> <skill-root>/scripts/run_bal_command.py \
-  "bal openapi -i <ALIGNED_SPEC> -o <BALLERINA_DIR> --license <LICENSE_PATH> [--tags <tags>] [--operations <ops>] [--client-methods remote] --mode client" \
+  "bal openapi -i '<ALIGNED_SPEC>' -o '<BALLERINA_DIR>' --license '<LICENSE_PATH>' [--tags <tags>] [--operations <ops>] [--client-methods remote] --mode client" \
   "<BALLERINA_DIR>"
 ```
 
@@ -69,7 +82,24 @@ Run `bal build` in `<BALLERINA_DIR>`:
 
 ---
 
-## Step 4: Stage completion
+## Step 4: Recommend a semantic-version update
+
+Run this only if client generation itself succeeded. It compares the pre-generation snapshot with the final, fixed `client.bal` and `types.bal`; tests, examples, and docs are never included.
+
+```bash
+<PYTHON_CMD> <skill-root>/scripts/client_version_summary.py diff \
+  "<BALLERINA_DIR>" "<BALLERINA_DIR>/.client_version_baseline.json"
+```
+
+- `skipped` is non-empty → print that status and continue.
+- Empty `diff` → report that no version bump is required.
+- Otherwise, ask AI to classify only the supplied diff as `MAJOR`, `MINOR`, or `PATCH`, with a concise rationale. Recommend `<major+1>.0.0`, `<major>.<minor+1>.0`, or `<major>.<minor>.<patch+1>` from the reported package version. Classification failure is a warning only.
+
+Delete `.client_version_baseline.json` after reporting.
+
+---
+
+## Step 5: Stage completion
 
 Print:
 ```

--- a/agent-skills/skills/generating-connectors/stages/03-tests.md
+++ b/agent-skills/skills/generating-connectors/stages/03-tests.md
@@ -166,13 +166,20 @@ final string token = isLiveServer ? os:getEnv("<CRED_ENV_VAR>") : "test_token";
 
 ---
 
-## Step 5: Run tests
+## Step 5: Run and repair generated tests
 
 ```bash
 <PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal test" "<BALLERINA_DIR>"
 ```
 
-Test failures are **non-fatal** — record the result and continue. Print the test summary.
+If `bal test` succeeds, record the passing result. On failure, repair only generated test files under `tests/` using this bounded loop:
+
+1. Combine stdout and stderr; select `tests/mock_service.bal` and/or `tests/test.bal` only when their path or basename appears in diagnostics. If neither is named, try `tests/test.bal` first, then the generated mock service.
+2. Give AI the failing file's current contents, relevant type context, stdout, stderr, and the attempt number. Require raw replacement source and prohibit changes outside `tests/test.bal` and `tests/mock_service.bal`.
+3. Apply only a non-empty, changed response, then rerun `bal test`.
+4. Stop when tests pass, diagnostics are unchanged from the prior attempt, AI produces no applicable edit, no generated test files exist, or the normal fix iteration limit is reached.
+
+Remaining test failures are non-fatal: print the final diagnostics and record the number of repair attempts. Do not invoke the general client fix procedure for a runtime test failure.
 
 ---
 

--- a/agent-skills/skills/generating-connectors/stages/03-tests.md
+++ b/agent-skills/skills/generating-connectors/stages/03-tests.md
@@ -158,7 +158,7 @@ final string token = isLiveServer ? os:getEnv("<CRED_ENV_VAR>") : "test_token";
 ## Step 4: Compile and fix
 
 ```bash
-<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal build" "<BALLERINA_DIR>"
+<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py --cwd "<BALLERINA_DIR>" bal build
 ```
 
 - Exit 0 → clean, continue
@@ -169,17 +169,18 @@ final string token = isLiveServer ? os:getEnv("<CRED_ENV_VAR>") : "test_token";
 ## Step 5: Run and repair generated tests
 
 ```bash
-<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal test" "<BALLERINA_DIR>"
+<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py --cwd "<BALLERINA_DIR>" bal test
 ```
 
-If `bal test` succeeds, record the passing result. On failure, repair only generated test files under `tests/` using this bounded loop:
+If `bal test` succeeds, record the passing result. On failure, use the runner's saved stderr path with `parse_errors.py` to obtain structured diagnostics. Repair only eligible generated test files under `tests/` using this bounded loop:
 
-1. Combine stdout and stderr; select `tests/mock_service.bal` and/or `tests/test.bal` only when their path or basename appears in diagnostics. If neither is named, try `tests/test.bal` first, then the generated mock service.
-2. Give AI the failing file's current contents, relevant type context, stdout, stderr, and the attempt number. Require raw replacement source and prohibit changes outside `tests/test.bal` and `tests/mock_service.bal`.
-3. Apply only a non-empty, changed response, then rerun `bal test`.
-4. Stop when tests pass, diagnostics are unchanged from the prior attempt, AI produces no applicable edit, no generated test files exist, or the normal fix iteration limit is reached.
+1. Keep only parseable `ERROR` diagnostics for `.bal` files whose normalized path resolves to `<BALLERINA_DIR>/tests/test.bal` or `<BALLERINA_DIR>/tests/mock_service.bal`. Ignore runtime failures, pathless diagnostics, diagnostics for other files, and warnings.
+2. If no eligible diagnostics or generated target files exist, stop without an AI repair attempt and record that test repair was skipped because no eligible compilation diagnostics were found.
+3. Give AI only each eligible file's current contents, relevant type context, structured diagnostics, and the attempt number. Require raw replacement source and prohibit changes outside `tests/test.bal` and `tests/mock_service.bal`.
+4. Apply only a non-empty, changed response, then rerun `bal test` and parse its new stderr diagnostics.
+5. Stop when tests pass, eligible diagnostics are unchanged from the prior attempt, AI produces no applicable edit, no eligible diagnostics remain, or the normal fix iteration limit is reached.
 
-Remaining test failures are non-fatal: print the final diagnostics and record the number of repair attempts. Do not invoke the general client fix procedure for a runtime test failure.
+Remaining test failures are non-fatal: print the final diagnostics and record the actual number of compilation-repair attempts (or that none were attempted because no eligible diagnostics existed). Do not invoke the general client fix procedure.
 
 ---
 
@@ -192,6 +193,7 @@ Print:
   test suite:  <BALLERINA_DIR>/tests/test.bal
   build:       passed (fixed in <N> iteration(s) / clean)
   test run:    <N passing, M failing / skipped>
+  test repair: <N compilation-repair attempt(s) / skipped: no eligible diagnostics>
 ```
 
 If `INTERACTIVE_MODE` is true, pause and ask: "Proceed to Examples? [Y/n/q]"

--- a/agent-skills/skills/generating-connectors/stages/04-examples.md
+++ b/agent-skills/skills/generating-connectors/stages/04-examples.md
@@ -43,8 +43,8 @@ Store as `TOML_META`. Use `TOML_META.distribution` and `TOML_META.version` when 
 Before generating any examples, publish the connector so that each example's `import <BAL_ORG>/<BAL_PACKAGE>` can resolve at build time:
 
 ```bash
-<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal pack" "<BALLERINA_DIR>"
-<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal push --repository=local" "<BALLERINA_DIR>"
+<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py --cwd "<BALLERINA_DIR>" bal pack
+<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py --cwd "<BALLERINA_DIR>" bal push --repository=local
 ```
 
 `bal pack` creates the `.bala` archive in `target/`; `bal push --repository=local` publishes it to `~/.ballerina/repositories/local/bala/` so examples can resolve the import at build time.
@@ -136,7 +136,7 @@ The `[[dependency]]` block with `repository = "local"` lets the example resolve 
 ### 3f: Compile and fix
 
 ```bash
-<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py "bal build" "<EXAMPLE_DIR>/<EXAMPLE_NAME>"
+<PYTHON_CMD> <skill-root>/scripts/run_bal_command.py --cwd "<EXAMPLE_DIR>/<EXAMPLE_NAME>" bal build
 ```
 
 - Exit 0 → clean

--- a/agent-skills/skills/generating-connectors/stages/04-examples.md
+++ b/agent-skills/skills/generating-connectors/stages/04-examples.md
@@ -6,6 +6,20 @@ Skip this stage if `examples` is in `EXCLUDED_STAGES`.
 
 ---
 
+## Step 0: Safely replace or retain examples
+
+If this stage is running, clean only recognized generated use-case packages before creating replacements:
+
+```bash
+<PYTHON_CMD> <skill-root>/scripts/manage_examples.py cleanup "<EXAMPLE_DIR>"
+```
+
+The script recognizes only immediate child directories containing both `main.bal` and `Ballerina.toml`; it does not remove hand-authored files or directories. If cleanup reports any failure, **skip example generation entirely** and report the failures to avoid a mixed old/new set.
+
+If `examples` is in `EXCLUDED_STAGES`, do not generate anything. Instead run `manage_examples.py scan "<EXAMPLE_DIR>"`, pack and push the current connector once, and run `bal build` plus the normal compilation fix procedure for each retained package. Report every retained package's result; unresolved packages are warnings, not a pipeline failure.
+
+---
+
 ## Step 1: Analyse the client and connector metadata
 
 Run both scripts upfront — this replaces all inline file reading for this stage:
@@ -132,21 +146,7 @@ Compilation errors in examples are **non-fatal if fix fails** — warn the user 
 
 ---
 
-## Step 4: Write `<EXAMPLE_DIR>/README.md`
-
-Read `<skill-root>/templates/examples_readme_template.md`.
-
-Fill in:
-- `<BAL_ORG>/<BAL_PACKAGE>` → from shared state
-- Example table rows — one row per example generated in Step 3 (`<example-name>` and USE_CASE one-liner)
-- `<BALLERINA_DIR>` → the connector output directory path
-- Auth field names (`<auth_field_1>`, `<auth_field_2>`) → from `SPEC_METADATA.securitySchemes`
-
-Write the filled content to `<EXAMPLE_DIR>/README.md`.
-
----
-
-## Stage completion
+## Step 4: Stage completion
 
 Print:
 ```

--- a/agent-skills/skills/generating-connectors/stages/05-docs.md
+++ b/agent-skills/skills/generating-connectors/stages/05-docs.md
@@ -51,7 +51,7 @@ Replace each `[//]: # (TODO: ...)` section with generated content:
 - **Overview**: 3–5 sentences describing what the API does and what this connector enables. Derived from `SPEC_METADATA.description` and title.
 - **Setup guide**: Numbered steps to obtain credentials and configure the connector. Derived from `SPEC_METADATA.securitySchemes` — list the required fields (API keys, OAuth tokens, etc.) and how to get them.
 - **Quickstart**: One short Ballerina code snippet showing a single representative API call. Use a simple GET or list operation from `CLIENT_ANALYSIS.methods`. Include the `Config.toml` snippet needed.
-- **Examples**: Bullet list of example names and one-line descriptions from `EXAMPLE_DIR` subdirectory names. Format: `[example-name](examples/example-name) — <one liner>`.
+- **Examples**: Bullet list of documented example names and one-line descriptions. Format: `[example-name](examples/example-name/example-name.md) — <one liner>`. Include only packages whose named document exists.
 
 Copy all other sections (Build from source, Build options, Contribute, Code of conduct, Useful links) verbatim from the template.
 
@@ -73,7 +73,7 @@ Write to `<BALLERINA_DIR>/Module.md`.
 
 ---
 
-## Step 4: Generate sub-READMEs
+## Step 4: Generate sub-documents
 
 ### Tests README
 
@@ -85,6 +85,12 @@ Fill in `AI_GENERATED_TESTING_APPROACH` with a short description of what the tes
 
 Write to `<BALLERINA_DIR>/tests/README.md`.
 
+### Individual example documents — generate first
+
+For every example package, generate the required file `<EXAMPLE_DIR>/<name>/<name>.md` before any aggregate documentation. Use `templates/example_readme_template.md`, with a human-readable title and a 2–3 sentence use-case description. Preserve the exact directory-name casing in the filename.
+
+If individual generation fails, warn and omit that example from aggregates; never create a broken link.
+
 ### Examples README
 
 Check if `<EXAMPLE_DIR>/README.md` already exists:
@@ -93,16 +99,12 @@ Check if `<EXAMPLE_DIR>/README.md` already exists:
 
 Fill in:
 - `<BAL_ORG>/<BAL_PACKAGE>` → from shared state
-- Example table rows — one row per subdirectory in `EXAMPLE_DIR`
+- Example table rows — one row per subdirectory whose `<name>.md` exists, with the direct relative link `./<name>/<name>.md`
 - Auth field names from `SPEC_METADATA.securitySchemes`
 
 Write to `<EXAMPLE_DIR>/README.md`.
 
-### Per-example READMEs (generate if time permits)
-
-For each example subdirectory that does not already have a `README.md`, read `<skill-root>/templates/example_readme_template.md` and fill in:
-- `<EXAMPLE_TITLE>` → human-readable name from the directory kebab slug
-- `AI_GENERATED_DESCRIPTION` → 2–3 sentences describing the use case
+Root/package README and Module.md example lists must likewise link directly to `examples/<name>/<name>.md` and include only documented examples. Do not alter a repository-root README outside `BALLERINA_DIR` that uses directory links.
 
 ---
 

--- a/agent-skills/skills/generating-connectors/stages/05-docs.md
+++ b/agent-skills/skills/generating-connectors/stages/05-docs.md
@@ -42,16 +42,25 @@ Do **not** re-read the entire source files — use the structured metadata and f
 ## Step 2: Generate root README
 
 Check if `<BALLERINA_DIR>/README.md` already exists:
-- **Exists** → use it as the base. It may already have some or all `[//]: # (TODO: ...)` sections and `{{PLACEHOLDER}}` variables filled. Only replace what is still unfilled — do not overwrite content that is already present.
+- **Exists** → use it as the base. It may already have some or all `[//]: # (TODO: ...)` sections and `{{PLACEHOLDER}}` variables filled. Only replace what is still unfilled, except reconcile generated example entries as specified in Step 4; do not overwrite other existing content.
 - **Absent** → read `<skill-root>/templates/readme_template.md` and proceed as below.
 
 Replace all `{{PLACEHOLDER}}` variables using the mapping above.
+
+Before rendering either root/package README or `Module.md` example list, derive each documented example's link target from its generated document path:
+
+```text
+example_doc = <EXAMPLE_DIR>/<name>/<name>.md
+example_link = relative path from <BALLERINA_DIR> to example_doc, with path separators normalized to `/`
+```
+
+For example, when `EXAMPLE_DIR` is `./examples`, `example_link` is `examples/<name>/<name>.md`; a custom example directory may yield `custom-examples/<name>/<name>.md` or `../examples/<name>/<name>.md`.
 
 Replace each `[//]: # (TODO: ...)` section with generated content:
 - **Overview**: 3–5 sentences describing what the API does and what this connector enables. Derived from `SPEC_METADATA.description` and title.
 - **Setup guide**: Numbered steps to obtain credentials and configure the connector. Derived from `SPEC_METADATA.securitySchemes` — list the required fields (API keys, OAuth tokens, etc.) and how to get them.
 - **Quickstart**: One short Ballerina code snippet showing a single representative API call. Use a simple GET or list operation from `CLIENT_ANALYSIS.methods`. Include the `Config.toml` snippet needed.
-- **Examples**: Bullet list of documented example names and one-line descriptions. Format: `[example-name](examples/example-name/example-name.md) — <one liner>`. Include only packages whose named document exists.
+- **Examples**: Bullet list of documented example names and one-line descriptions. Format: `[example-name](<example_link>) — <one liner>`. Include only packages whose named document exists.
 
 Copy all other sections (Build from source, Build options, Contribute, Code of conduct, Useful links) verbatim from the template.
 
@@ -62,7 +71,7 @@ Write to `<BALLERINA_DIR>/README.md`.
 ## Step 3: Generate Module.md (Ballerina Central)
 
 Check if `<BALLERINA_DIR>/Module.md` already exists:
-- **Exists** → use it as the base. Only replace sections that still contain unfilled `[//]: # (TODO: ...)` markers or unresolved `{{PLACEHOLDER}}` variables. Do not overwrite already-filled content.
+- **Exists** → use it as the base. Only replace sections that still contain unfilled `[//]: # (TODO: ...)` markers or unresolved `{{PLACEHOLDER}}` variables, except reconcile generated example entries as specified in Step 4. Do not overwrite other already-filled content.
 - **Absent** → read `<skill-root>/templates/module_readme_template.md` and proceed as below.
 
 Replace all `{{PLACEHOLDER}}` variables using the mapping above.
@@ -87,24 +96,26 @@ Write to `<BALLERINA_DIR>/tests/README.md`.
 
 ### Individual example documents — generate first
 
-For every example package, generate the required file `<EXAMPLE_DIR>/<name>/<name>.md` before any aggregate documentation. Use `templates/example_readme_template.md`, with a human-readable title and a 2–3 sentence use-case description. Preserve the exact directory-name casing in the filename.
+For every example package, generate the required file `<EXAMPLE_DIR>/<name>/<name>.md` before any aggregate documentation. Use `templates/example_readme_template.md`, with a human-readable title and a 2–3 sentence use-case description. Preserve the exact directory-name casing in the filename. Build `DOCUMENTED_EXAMPLES` from only the package names whose named document was generated successfully or confirmed present for this run.
 
-If individual generation fails, warn and omit that example from aggregates; never create a broken link.
+If individual generation fails, warn and omit that example from `DOCUMENTED_EXAMPLES`; never create a broken link.
 
 ### Examples README
 
 Check if `<EXAMPLE_DIR>/README.md` already exists:
-- **Exists** → use it as the base. Update or add example table rows for any new examples added since the last run. Only replace `<angle-bracket>` placeholders that are still unfilled. Do not overwrite content that is already present.
+- **Exists** → use it as the base. Reconcile generated example table rows as specified below and replace `<angle-bracket>` placeholders that are still unfilled. Do not overwrite other existing content.
 - **Absent** → read `<skill-root>/templates/examples_readme_template.md` and proceed as below.
 
 Fill in:
 - `<BAL_ORG>/<BAL_PACKAGE>` → from shared state
-- Example table rows — one row per subdirectory whose `<name>.md` exists, with the direct relative link `./<name>/<name>.md`
+- Example table rows — one row per `DOCUMENTED_EXAMPLES` entry, with the direct relative link `./<name>/<name>.md`
 - Auth field names from `SPEC_METADATA.securitySchemes`
 
 Write to `<EXAMPLE_DIR>/README.md`.
 
-Root/package README and Module.md example lists must likewise link directly to `examples/<name>/<name>.md` and include only documented examples. Do not alter a repository-root README outside `BALLERINA_DIR` that uses directory links.
+Reconcile all aggregate example sections against `DOCUMENTED_EXAMPLES` before writing. Replace or prune only generated entries: table rows that use the generated direct-link form `./<name>/<name>.md`, and README/Module.md bullets that use the generated computed `example_link` convention. Remove matching stale entries for packages not in `DOCUMENTED_EXAMPLES`, add or replace entries for packages in it, and preserve unrelated user-authored prose, rows, links, headings, and aggregate structure.
+
+Root/package README and Module.md example lists must use the computed `example_link` value for every `DOCUMENTED_EXAMPLES` entry. Do not alter a repository-root README outside `BALLERINA_DIR` that uses directory links.
 
 ---
 

--- a/agent-skills/skills/generating-connectors/templates/examples_readme_template.md
+++ b/agent-skills/skills/generating-connectors/templates/examples_readme_template.md
@@ -4,7 +4,7 @@ The `<BAL_ORG>/<BAL_PACKAGE>` connector provides practical examples illustrating
 
 | Example | Description |
 |---------|-------------|
-| [`<example-name>`](./<example-name>) | <USE_CASE one-liner> |
+| [`<example-name>`](./<example-name>/<example-name>.md) | <USE_CASE one-liner> |
 
 ## Prerequisites
 

--- a/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
+++ b/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
@@ -101,6 +101,11 @@ class VersionAndExampleTests(unittest.TestCase):
         (example / "Ballerina.toml").write_text("", encoding="utf-8")
         return example
 
+    def create_quarantine(self, root: Path, name: str) -> Path:
+        quarantine = root / f".generated-examples-quarantine-{name}"
+        quarantine.mkdir()
+        return quarantine
+
     def test_baseline_ignores_comment_only_client_and_normalizes_line_endings(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             directory = Path(temp)
@@ -153,6 +158,68 @@ class VersionAndExampleTests(unittest.TestCase):
                 self.assertTrue((example / "main.bal").is_file())
                 self.assertTrue((example / "Ballerina.toml").is_file())
             self.assertTrue((preserved / "README.md").is_file())
+
+    def test_example_scan_recovers_stale_quarantine(self) -> None:
+        module = load_script_module("manage_examples.py")
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            quarantine = self.create_quarantine(root, "interrupted")
+            self.create_example(quarantine, "recovered")
+            output = io.StringIO()
+
+            with contextlib.redirect_stdout(output):
+                module.scan(root)
+
+            result = json.loads(output.getvalue())
+            self.assertEqual(result, {"examples": ["recovered"], "count": 1})
+            self.assertTrue((root / "recovered" / "main.bal").is_file())
+            self.assertFalse(quarantine.exists())
+
+    def test_example_cleanup_reports_stale_quarantine_conflicts_without_deleting(self) -> None:
+        module = load_script_module("manage_examples.py")
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            visible = self.create_example(root, "duplicate")
+            quarantine = self.create_quarantine(root, "interrupted")
+            self.create_example(quarantine, "duplicate")
+            output = io.StringIO()
+
+            with patch.object(module.shutil, "rmtree") as delete_quarantine:
+                with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as exit_info:
+                    module.cleanup(root)
+
+            result = json.loads(output.getvalue())
+            self.assertEqual(exit_info.exception.code, 1)
+            self.assertEqual(result["removed"], [])
+            self.assertTrue(result["failures"])
+            self.assertFalse(result["complete"])
+            self.assertTrue((visible / "main.bal").is_file())
+            self.assertTrue((quarantine / "duplicate" / "main.bal").is_file())
+            delete_quarantine.assert_not_called()
+
+    def test_example_cleanup_marks_failed_rollback_as_removed(self) -> None:
+        module = load_script_module("manage_examples.py")
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.create_example(root, "first")
+            original_rename = Path.rename
+            output = io.StringIO()
+
+            def fail_rollback(path: Path, target: Path) -> Path:
+                if path.parent.name.startswith(module.QUARANTINE_PREFIX) and path.name == "first":
+                    raise OSError("simulated restore failure")
+                return original_rename(path, target)
+
+            with patch.object(module.shutil, "rmtree", side_effect=OSError("simulated deletion failure")):
+                with patch.object(Path, "rename", new=fail_rollback):
+                    with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as exit_info:
+                        module.cleanup(root)
+
+            result = json.loads(output.getvalue())
+            self.assertEqual(exit_info.exception.code, 1)
+            self.assertEqual(result["removed"], ["first"])
+            self.assertTrue(any("restore failed" in failure for failure in result["failures"]))
+            self.assertFalse((root / "first").exists())
 
     def test_bal_runner_uses_argv_without_a_shell(self) -> None:
         module = load_script_module("run_bal_command.py")

--- a/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
+++ b/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+
+def run(script: str, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(SCRIPTS / script), *args], text=True,
+                          capture_output=True, check=check)
+
+
+class SchemaMappingTests(unittest.TestCase):
+    def write_spec(self, directory: Path, schemas: dict) -> Path:
+        path = directory / "aligned.json"
+        spec = {
+            "openapi": "3.0.0",
+            "components": {"schemas": schemas},
+            "paths": {
+                "/items": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/InlineResponse200"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        path.write_text(json.dumps(spec), encoding="utf-8")
+        return path
+
+    def test_initial_and_rerun_mappings_are_stable_and_pruned(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            spec = self.write_spec(directory, {"InlineResponse200": {"type": "object"}, "User": {"type": "object"}})
+            mappings, candidate, decisions = directory / "ai-mappings.json", directory / "candidate.json", directory / "decisions.json"
+            prepared = json.loads(run("schema_mappings.py", "prepare", str(spec), str(mappings), str(candidate)).stdout)
+            self.assertEqual({item["name"] for item in prepared["unseen_schemas"]}, {"InlineResponse200", "User"})
+            decisions.write_text(json.dumps({"InlineResponse200": "UserListResponse", "User": "User"}), encoding="utf-8")
+            run("schema_mappings.py", "apply", str(spec), str(candidate), str(decisions), str(mappings))
+            generated = json.loads(spec.read_text(encoding="utf-8"))
+            self.assertIn("UserListResponse", generated["components"]["schemas"])
+            self.assertEqual(generated["paths"]["/items"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]["$ref"], "#/components/schemas/UserListResponse")
+            persisted = json.loads(mappings.read_text(encoding="utf-8"))
+            persisted["operationIds"] = {"/items": {"get": "listItems"}}
+            mappings.write_text(json.dumps(persisted), encoding="utf-8")
+
+            # A future flattened spec retains only known User plus a new schema.
+            spec = self.write_spec(directory, {"User": {"type": "object"}, "Order": {"type": "object"}})
+            prepared = json.loads(run("schema_mappings.py", "prepare", str(spec), str(mappings), str(candidate)).stdout)
+            self.assertEqual([item["name"] for item in prepared["unseen_schemas"]], ["Order"])
+            self.assertEqual(prepared["pruned_schema_names"], ["InlineResponse200"])
+            decisions.write_text(json.dumps({"Order": "Order"}), encoding="utf-8")
+            run("schema_mappings.py", "apply", str(spec), str(candidate), str(decisions), str(mappings))
+            persisted = json.loads(mappings.read_text(encoding="utf-8"))
+            self.assertEqual(set(persisted["schemaNames"]), {"User", "Order"})
+            self.assertEqual(persisted["operationIds"], {"/items": {"get": "listItems"}})
+
+    def test_collision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            spec = self.write_spec(directory, {"A": {}, "B": {}})
+            mappings, candidate, decisions = directory / "mappings.json", directory / "candidate.json", directory / "decisions.json"
+            run("schema_mappings.py", "prepare", str(spec), str(mappings), str(candidate))
+            decisions.write_text(json.dumps({"A": "Same", "B": "Same"}), encoding="utf-8")
+            result = run("schema_mappings.py", "apply", str(spec), str(candidate), str(decisions), str(mappings), check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("duplicate", result.stderr)
+
+
+class VersionAndExampleTests(unittest.TestCase):
+    def test_baseline_ignores_comment_only_client_and_normalizes_line_endings(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            (directory / "client.bal").write_text("// generated\n# comment\n", encoding="utf-8")
+            baseline = directory / "baseline.json"
+            run("client_version_summary.py", "capture", str(directory), str(baseline))
+            result = json.loads(run("client_version_summary.py", "diff", str(directory), str(baseline)).stdout)
+            self.assertEqual(result["skipped"], "no meaningful previous client.bal")
+
+            with open(directory / "client.bal", "w", encoding="utf-8", newline="") as client:
+                client.write("public class Client {}\r\n")
+            run("client_version_summary.py", "capture", str(directory), str(baseline))
+            (directory / "client.bal").write_text("public class Client {}\n", encoding="utf-8")
+            result = json.loads(run("client_version_summary.py", "diff", str(directory), str(baseline)).stdout)
+            self.assertEqual(result["skipped"], "no client/types changes")
+
+    def test_example_cleanup_only_removes_recognized_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            generated = root / "generated"
+            generated.mkdir()
+            (generated / "main.bal").write_text("", encoding="utf-8")
+            (generated / "Ballerina.toml").write_text("", encoding="utf-8")
+            preserved = root / "notes"
+            preserved.mkdir()
+            (preserved / "README.md").write_text("keep", encoding="utf-8")
+            result = json.loads(run("manage_examples.py", "cleanup", str(root)).stdout)
+            self.assertEqual(result["removed"], ["generated"])
+            self.assertTrue(preserved.is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
+++ b/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import contextlib
+import importlib.util
+import io
 import json
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,6 +19,14 @@ SCRIPTS = ROOT / "scripts"
 def run(script: str, *args: str, check: bool = True) -> subprocess.CompletedProcess:
     return subprocess.run([sys.executable, str(SCRIPTS / script), *args], text=True,
                           capture_output=True, check=check)
+
+
+def load_script_module(script: str):
+    spec = importlib.util.spec_from_file_location(script.removesuffix(".py"), SCRIPTS / script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class SchemaMappingTests(unittest.TestCase):
@@ -82,6 +94,13 @@ class SchemaMappingTests(unittest.TestCase):
 
 
 class VersionAndExampleTests(unittest.TestCase):
+    def create_example(self, root: Path, name: str) -> Path:
+        example = root / name
+        example.mkdir()
+        (example / "main.bal").write_text("", encoding="utf-8")
+        (example / "Ballerina.toml").write_text("", encoding="utf-8")
+        return example
+
     def test_baseline_ignores_comment_only_client_and_normalizes_line_endings(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             directory = Path(temp)
@@ -101,16 +120,71 @@ class VersionAndExampleTests(unittest.TestCase):
     def test_example_cleanup_only_removes_recognized_packages(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            generated = root / "generated"
-            generated.mkdir()
-            (generated / "main.bal").write_text("", encoding="utf-8")
-            (generated / "Ballerina.toml").write_text("", encoding="utf-8")
+            self.create_example(root, "generated")
             preserved = root / "notes"
             preserved.mkdir()
             (preserved / "README.md").write_text("keep", encoding="utf-8")
             result = json.loads(run("manage_examples.py", "cleanup", str(root)).stdout)
             self.assertEqual(result["removed"], ["generated"])
             self.assertTrue(preserved.is_dir())
+
+    def test_example_cleanup_restores_packages_when_quarantine_deletion_fails(self) -> None:
+        module = load_script_module("manage_examples.py")
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            first = self.create_example(root, "first")
+            second = self.create_example(root, "second")
+            preserved = root / "notes"
+            preserved.mkdir()
+            (preserved / "README.md").write_text("keep", encoding="utf-8")
+            output = io.StringIO()
+
+            with patch.object(module.shutil, "rmtree", side_effect=OSError("simulated deletion failure")):
+                with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as exit_info:
+                    module.cleanup(root)
+
+            result = json.loads(output.getvalue())
+            self.assertEqual(exit_info.exception.code, 1)
+            self.assertEqual(result["removed"], [])
+            self.assertTrue(result["failures"])
+            self.assertFalse(result["complete"])
+            for example in (first, second):
+                self.assertTrue((example / "main.bal").is_file())
+                self.assertTrue((example / "Ballerina.toml").is_file())
+            self.assertTrue((preserved / "README.md").is_file())
+
+    def test_bal_runner_uses_argv_without_a_shell(self) -> None:
+        module = load_script_module("run_bal_command.py")
+        with tempfile.TemporaryDirectory() as temp:
+            command = ["bal", "openapi", "-i", "spec with spaces.yaml"]
+            with patch.object(module.subprocess, "run", return_value=subprocess.CompletedProcess(command, 0, "", "")) as run_command:
+                with patch.object(sys, "argv", ["run_bal_command.py", "--cwd", temp, *command]):
+                    with self.assertRaises(SystemExit) as exit_info:
+                        module.main()
+
+            self.assertEqual(exit_info.exception.code, 0)
+            run_command.assert_called_once_with(
+                command, shell=False, cwd=temp, capture_output=True, text=True,
+                timeout=module.DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    def test_bal_runner_decodes_byte_timeout_output(self) -> None:
+        module = load_script_module("run_bal_command.py")
+        with tempfile.TemporaryDirectory() as temp:
+            command = ["bal", "build"]
+            timeout = subprocess.TimeoutExpired(command, 1, output=b"stdout\xff", stderr=b"stderr\xff")
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with patch.object(module.subprocess, "run", side_effect=timeout):
+                with patch.object(sys, "argv", ["run_bal_command.py", "--cwd", temp, *command]):
+                    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                        with self.assertRaises(SystemExit) as exit_info:
+                            module.main()
+
+            self.assertEqual(exit_info.exception.code, 124)
+            self.assertIn("stdout�", stdout.getvalue())
+            self.assertIn("stderr�", stderr.getvalue())
+            self.assertIn("Command timed out after", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

  The `generating-connectors` skill did not fully reflect the connector-tool regeneration workflow. In particular, it lacked stable schema-name decisions across reruns, source-based semantic-version
  recommendations, bounded generated-test repair, safe retained-example handling, and directly linked per-example documentation.

References: https://github.com/ballerina-platform/ballerina-library/issues/8791

  ## Goals

  - Keep AI schema naming stable across initial generation and regeneration.
  - Improve generated connector validation and recovery guidance.
  - Safely regenerate or retain examples.
  - Provide semantic-version recommendations based only on generated client API changes.
  - Produce complete, directly linked example documentation.

  ## Approach

  - Added `schema_mappings.py` to persist `ai-mappings.json` schema decisions, reuse mappings, prune obsolete mappings, prevent collisions, rewrite local schema references, and atomically save artifacts.
  - Added source-snapshot client/types comparison for semantic-version recommendations.
  - Added safe generated-example discovery and cleanup helpers.
  - Added command timeout handling and atomic operation-ID persistence.
  - Updated sanitize, client, tests, examples, and documentation workflow instructions to mirror connector-tool behavior.
  - Added focused Python tests for schema mappings, version baselines, and example cleanup.

  No UI changes; screenshots/GIFs are not applicable.

  ## Related PRs

  - https://github.com/ballerina-platform/connector-tool/pull/7
  - https://github.com/ballerina-platform/connector-tool/pull/8
  - https://github.com/ballerina-platform/connector-tool/pull/9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the `generating-connectors` skill workflow and documentation to align with the connector-tool regeneration workflow, refining stage contracts and improving end-of-run reporting/output structure.
- Added persistent, atomic OpenAPI schema-mapping support (`schema_mappings.py` + `ai-mappings.json`) to stabilize AI-driven schema naming across regenerations, prune obsolete mappings, prevent naming collisions, validate AI decisions coverage/uniqueness, rewrite internal `$ref` references, and safely apply renames with retries/fallbacks.
- Introduced client snapshot tooling (`client_version_summary.py`) to capture and diff generated `client.bal`/`types.bal` baselines (without Git), enabling semantic-version recommendations based on meaningful changes.
- Strengthened generated example package handling (`manage_examples.py`) with quarantine-based reconciliation, failure-aware scan/cleanup, rollback-aware cleanup behavior, and updated behavior when the examples stage is excluded.
- Improved workflow robustness and execution consistency across stages by standardizing working-directory/argument handling for Ballerina CLI commands, adding configurable subprocess command timeout enforcement, and persisting key workflow state using atomic writes (including aligned spec updates and prior operation-id/state restoration).
- Expanded automated test coverage to validate schema-mapping stability and pruning, client baseline/diff behavior, example quarantine recovery/rollback edge cases, and runner timeout/subprocess behavior; updated scripts workflow instructions and docs/templates (including example README link targeting).
- Bumped the plugin version to `0.2.0` and ensured it is displayed in the connector banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->