### PR TITLE
Align connector generation skill with connector tool sanitization improvements

### DIFF
--- a/agent-skills/.claude-plugin/plugin.json
+++ b/agent-skills/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ballerina-libdev",
   "displayName": "Ballerina Library Development",
   "description": "Agent skills for developing and maintaining Ballerina library modules.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "WSO2",
     "url": "https://wso2.com"

--- a/agent-skills/.claude-plugin/plugin.json
+++ b/agent-skills/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ballerina-libdev",
   "displayName": "Ballerina Library Development",
   "description": "Agent skills for developing and maintaining Ballerina library modules.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "WSO2",
     "url": "https://wso2.com"

--- a/agent-skills/skills/generating-connectors/SKILL.md
+++ b/agent-skills/skills/generating-connectors/SKILL.md
@@ -46,7 +46,7 @@ When this skill is invoked:
    ```
    ╔══════════════════════════════════════════╗
    ║       Ballerina Connector Generator      ║
-   ╚════════════════════════════════ ᵥ₀․₃․₀ ══╝
+   ╚════════════════════════════════ ᵥ₀․₄․₀ ══╝
 
    I'll guide you through generating a Ballerina connector from your OpenAPI spec.
    This involves up to 5 stages: sanitize → client → tests → examples → docs.

--- a/agent-skills/skills/generating-connectors/scripts/operation_id_mappings.py
+++ b/agent-skills/skills/generating-connectors/scripts/operation_id_mappings.py
@@ -216,10 +216,12 @@ def apply(spec_path: str, candidate_path: str, decisions_path: str, output_path:
              ", ".join(f"{method} {path}" for path, method in unexpected))
 
     reserved = set(existing.values())
+    omitted: dict[tuple[str, str], str] = {}
     for location in unseen - set(decisions):
         operation_id = current[location].get("operationId")
         if isinstance(operation_id, str) and operation_id.strip():
-            reserved.add(operation_id.strip())
+            omitted[location] = operation_id.strip()
+            reserved.add(omitted[location])
     final_decisions: dict[tuple[str, str], str] = {}
     changed = 0
     for location in sorted(decisions, key=lambda item: (item[0], HTTP_METHODS.index(item[1]))):
@@ -236,7 +238,7 @@ def apply(spec_path: str, candidate_path: str, decisions_path: str, output_path:
         final_decisions[location] = final_id
         reserved.add(final_id)
 
-    merged = {**existing, **final_decisions}
+    merged = {**existing, **omitted, **final_decisions}
     candidate["operationIds"] = sorted_mappings(merged)
     atomic_write_json(spec_path, spec)
     atomic_write_json(output_path, ordered_document(candidate))

--- a/agent-skills/skills/generating-connectors/scripts/operation_id_mappings.py
+++ b/agent-skills/skills/generating-connectors/scripts/operation_id_mappings.py
@@ -216,6 +216,10 @@ def apply(spec_path: str, candidate_path: str, decisions_path: str, output_path:
              ", ".join(f"{method} {path}" for path, method in unexpected))
 
     reserved = set(existing.values())
+    for location in unseen - set(decisions):
+        operation_id = current[location].get("operationId")
+        if isinstance(operation_id, str) and operation_id.strip():
+            reserved.add(operation_id.strip())
     final_decisions: dict[tuple[str, str], str] = {}
     changed = 0
     for location in sorted(decisions, key=lambda item: (item[0], HTTP_METHODS.index(item[1]))):

--- a/agent-skills/skills/generating-connectors/scripts/spec_descriptions.py
+++ b/agent-skills/skills/generating-connectors/scripts/spec_descriptions.py
@@ -172,9 +172,12 @@ def parse_decisions(value: Any) -> dict[str, str]:
         fail("description decisions must be a JSON object")
     decisions: dict[str, str] = {}
     for request_id, description in value.items():
-        if not isinstance(request_id, str) or not isinstance(description, str) or not description.strip():
-            fail("description decisions must map request IDs to non-empty strings")
-        decisions[request_id] = description.strip().rstrip(".")
+        if not isinstance(request_id, str) or not isinstance(description, str):
+            fail("description decisions must map request IDs to non-placeholder descriptions")
+        normalized = description.strip().rstrip(".")
+        if invalid_description(normalized):
+            fail("description decisions must map request IDs to non-placeholder descriptions")
+        decisions[request_id] = normalized
     return decisions
 
 

--- a/agent-skills/skills/generating-connectors/stages/04-examples.md
+++ b/agent-skills/skills/generating-connectors/stages/04-examples.md
@@ -75,14 +75,20 @@ From `USE_CASE`, suggest a snake_case directory name:
 Good: `sharepoint_tenant_configuration`, `admin_settings_update`
 Bad: `get_sharepoint_example`, `getSharepoint_demo`
 
-Store the raw suggestion as `SUGGESTED_EXAMPLE_NAME`, then normalize it and resolve collisions deterministically:
+Store the raw suggestion as `SUGGESTED_EXAMPLE_NAME`, then normalize it and resolve collisions deterministically. Invoke the helper with an argument array so every value is passed as a separate argv element:
 
-```bash
-<PYTHON_CMD> <skill-root>/scripts/example_names.py resolve \
-  "<EXAMPLE_DIR>" "<SUGGESTED_EXAMPLE_NAME>" "example_<iteration-number>"
+```text
+[
+  <PYTHON_CMD>,
+  <skill-root>/scripts/example_names.py,
+  resolve,
+  <EXAMPLE_DIR>,
+  SUGGESTED_EXAMPLE_NAME,
+  example_<iteration-number>
+]
 ```
 
-Parse the returned JSON and store `name` as `EXAMPLE_NAME`. Use this exact value for the directory, Ballerina package name, named documentation file, and aggregate documentation links. The helper converts arbitrary suggestions to snake_case and appends `_2`, `_3`, and so on when any existing filesystem entry already uses the name.
+Never interpolate `SUGGESTED_EXAMPLE_NAME` into shell source, including inside ordinary double quotes; shell metacharacters in an AI-generated suggestion must remain literal argument data. Parse the returned JSON and store `name` as `EXAMPLE_NAME`. Use this exact value for the directory, Ballerina package name, named documentation file, and aggregate documentation links. The helper converts arbitrary suggestions to snake_case and appends `_2`, `_3`, and so on when any existing filesystem entry already uses the name.
 
 ### 3c: Extract targeted code context
 

--- a/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
+++ b/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
@@ -212,6 +212,34 @@ class OperationIdMappingTests(unittest.TestCase):
             self.assertEqual(persisted["custom"], "keep")
             self.assertNotIn("/stale", persisted["operationIds"])
 
+    def test_partial_apply_reserves_ids_from_omitted_operations(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            spec = directory / "aligned.json"
+            mappings = directory / "ai-mappings.json"
+            candidate = directory / "candidate.json"
+            decisions = directory / "decisions.json"
+            spec.write_text(json.dumps({
+                "openapi": "3.0.0",
+                "paths": {
+                    "/decided": {"post": {"operationId": "createItem"}},
+                    "/omitted": {"get": {"operationId": "listItems"}},
+                },
+            }), encoding="utf-8")
+            run("operation_id_mappings.py", "prepare", str(spec), str(mappings), str(candidate))
+            decisions.write_text(json.dumps({
+                "/decided": {"post": "listItems"},
+            }), encoding="utf-8")
+
+            result = json.loads(run(
+                "operation_id_mappings.py", "apply", str(spec), str(candidate),
+                str(decisions), str(mappings)).stdout)
+
+            generated = json.loads(spec.read_text(encoding="utf-8"))
+            self.assertEqual(result["pending_count"], 1)
+            self.assertEqual(generated["paths"]["/decided"]["post"]["operationId"], "listItems1")
+            self.assertEqual(generated["paths"]["/omitted"]["get"]["operationId"], "listItems")
+
     def test_duplicate_persisted_ids_are_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             directory = Path(temp)
@@ -398,11 +426,32 @@ class DescriptionTests(unittest.TestCase):
             requests = directory / "requests.json"
             decisions = directory / "decisions.json"
             run("spec_descriptions.py", "prepare", str(spec), str(requests))
-            decisions.write_text(json.dumps({"unknown": "Description"}), encoding="utf-8")
+            decisions.write_text(json.dumps({"unknown": "Useful description"}), encoding="utf-8")
             result = run("spec_descriptions.py", "apply", str(spec), str(requests),
                          str(decisions), check=False)
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("unknown description", result.stderr)
+
+    def test_normalized_empty_and_placeholder_decisions_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            spec = self.write_spec(directory)
+            requests = directory / "requests.json"
+            decisions = directory / "decisions.json"
+            prepared = json.loads(run(
+                "spec_descriptions.py", "prepare", str(spec), str(requests)).stdout)
+            request_id = prepared["requests"][0]["id"]
+            original = spec.read_text(encoding="utf-8")
+
+            for description in ("TBD", "TBD.", "  TBD.  ", ".", "..."):
+                with self.subTest(description=description):
+                    decisions.write_text(json.dumps({request_id: description}), encoding="utf-8")
+                    result = run(
+                        "spec_descriptions.py", "apply", str(spec), str(requests),
+                        str(decisions), check=False)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("non-placeholder descriptions", result.stderr)
+                    self.assertEqual(spec.read_text(encoding="utf-8"), original)
 
     def test_apply_preserves_description_added_after_prepare_and_rejects_duplicates(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
+++ b/agent-skills/skills/generating-connectors/tests/test_workflow_helpers.py
@@ -236,9 +236,11 @@ class OperationIdMappingTests(unittest.TestCase):
                 str(decisions), str(mappings)).stdout)
 
             generated = json.loads(spec.read_text(encoding="utf-8"))
+            persisted = json.loads(mappings.read_text(encoding="utf-8"))
             self.assertEqual(result["pending_count"], 1)
             self.assertEqual(generated["paths"]["/decided"]["post"]["operationId"], "listItems1")
             self.assertEqual(generated["paths"]["/omitted"]["get"]["operationId"], "listItems")
+            self.assertEqual(persisted["operationIds"]["/omitted"]["get"], "listItems")
 
     def test_duplicate_persisted_ids_are_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Purpose

The connector-generation skill was missing recent reliability improvements introduced in the connector tool:

- AI-reviewed operation IDs were restored from the previous aligned specification rather than persisted as validated decisions.
- Request bodies and API-key security schemes with missing descriptions could produce undocumented generated client fields.
- Specifications without `components.schemas` could fail during schema processing.
- Generated example names were not consistently valid, unique `snake_case` package names.
- The skill documentation and plugin version did not reflect these new capabilities.

References [ballerina-platform/ballerina-library#8791](https://github.com/ballerina-platform/ballerina-library/issues/8791).

## Goals

- Persist reviewed operation-ID decisions across connector regeneration runs.
- Validate new operation-ID decisions and deterministically resolve collisions.
- Prune operation-ID and schema-name mappings for removed specification elements.
- Enrich missing request-body and API-key security-scheme descriptions.
- Support OpenAPI specifications without component schemas.
- Generate stable, unique `snake_case` example directory and package names.
- Keep the skill documentation, plugin version, and displayed banner version synchronized.

## Approach

- Replaced prior-spec operation-ID restoration with `operation_id_mappings.py`, using a deterministic `prepare`/`apply` workflow.
- Persisted operation IDs in `ai-mappings.json`, keyed by exact OpenAPI path and HTTP method.
- Added validation for duplicate, malformed, empty, unsupported, and unexpected operation-ID decisions.
- Preserved unrelated and existing schema-name data when updating `ai-mappings.json`.
- Added `spec_descriptions.py` to collect and apply missing descriptions for:
  - Inline request bodies.
  - `apiKey` security schemes.
- Extended structured OpenAPI metadata extraction with request-body and security-scheme context.
- Updated schema mapping to accept missing or empty `components.schemas` and prune stale mappings.
- Added `example_names.py` to normalize names to `snake_case` and resolve collisions with numeric suffixes.
- Updated the sanitization and example-generation stage instructions to use the new deterministic helpers.
- Added regression tests for the new mapping, description, schema-less, and example-name behavior.
- Bumped the plugin version from `0.2.0` to `0.3.0` and synchronized the version displayed in the skill banner.

This change does not affect a graphical UI, so screenshots and UI-text review are not applicable.

## User stories

- As a connector maintainer, I want reviewed operation IDs to remain stable across regenerations so that downstream users do not receive unnecessary breaking changes.
- As a connector user, I want generated request payloads and API-key fields to have meaningful documentation.
- As a connector developer, I want schema-less OpenAPI specifications to complete sanitization successfully.
- As a connector maintainer, I want generated examples to use valid, predictable, and unique Ballerina package names.
- As a plugin user, I want the installed plugin version and displayed skill version to identify the capabilities being used accurately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved connector regeneration stability with persistent, validated operation-ID and schema-name mappings, including stale-mapping cleanup and support for specifications without schemas.
- Added enrichment for request-body and API-key security-scheme descriptions with validation safeguards.
- Standardized example names to deterministic, unique `snake_case` identifiers.
- Updated workflow documentation, plugin metadata, and displayed skill version.
- Expanded regression coverage for mapping persistence, validation, description handling, schema-less specifications, and example naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->