### PR TITLE
Standardize setup-ballerina action version across workflow templates

### DIFF
--- a/.github/workflows/build-connector-template.yml
+++ b/.github/workflows/build-connector-template.yml
@@ -48,7 +48,7 @@ jobs:
                 echo "Ballerina Version: $BAL_VERSION"
 
             - name: Set Up Ballerina
-              uses: ballerina-platform/setup-ballerina@v1.1.0
+              uses: ballerina-platform/setup-ballerina@v1.1.3
               with:
                 version: ${{ env.BAL_VERSION }}
 

--- a/.github/workflows/daily-build-connector-template.yml
+++ b/.github/workflows/daily-build-connector-template.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: latest
 

--- a/.github/workflows/dev-stage-central-publish-connector-template.yml
+++ b/.github/workflows/dev-stage-central-publish-connector-template.yml
@@ -38,7 +38,7 @@ jobs:
           echo "Ballerina Version: $BAL_VERSION"
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: ${{ env.BAL_VERSION }}
 

--- a/.github/workflows/release-package-connector-template.yml
+++ b/.github/workflows/release-package-connector-template.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Ballerina Version: $BAL_VERSION"
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: ${{ env.BAL_VERSION }}
 

--- a/.github/workflows/s4hana-build-connector-template.yml
+++ b/.github/workflows/s4hana-build-connector-template.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Ballerina Version: $BAL_VERSION"
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: ${{ env.BAL_VERSION }}
 

--- a/.github/workflows/s4hana-build-with-bal-test-graalvm.yml
+++ b/.github/workflows/s4hana-build-with-bal-test-graalvm.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: latest
 

--- a/.github/workflows/s4hana-daily-build-connector-template.yml
+++ b/.github/workflows/s4hana-daily-build-connector-template.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: latest
 

--- a/.github/workflows/s4hana-pr-template.yml
+++ b/.github/workflows/s4hana-pr-template.yml
@@ -95,7 +95,7 @@ jobs:
           echo "Ballerina Version: $BAL_VERSION"
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: ${{ env.BAL_VERSION }}
 

--- a/.github/workflows/s4hana-release-template.yml
+++ b/.github/workflows/s4hana-release-template.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Ballerina Version: $BAL_VERSION"
 
       - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.0
+        uses: ballerina-platform/setup-ballerina@v1.1.3
         with:
           version: ${{ env.BAL_VERSION }}
 


### PR DESCRIPTION
## Summary

Fixes #7647.

The reusable workflow templates in `.github/workflows/` used a mix of `ballerina-platform/setup-ballerina@v1.1.0` and `@v1.1.3`. Per the issue, `v1.1.2` onward is required to build with the nightly docker image, so the templates still pinned to `v1.1.0` are on an older, unsupported version for that use case.

## Change

Bumped the 9 remaining templates from `v1.1.0` to `v1.1.3`, matching what the other 7 templates in the repo already use:

- `daily-build-connector-template.yml`
- `s4hana-pr-template.yml`
- `build-connector-template.yml`
- `s4hana-build-connector-template.yml`
- `s4hana-release-template.yml`
- `s4hana-daily-build-connector-template.yml`
- `dev-stage-central-publish-connector-template.yml`
- `release-package-connector-template.yml`
- `s4hana-build-with-bal-test-graalvm.yml`

All `setup-ballerina` references in the repo now consistently use `v1.1.3`.

## Test plan

- [x] Verified via code search that all 17 `setup-ballerina` references in `.github/workflows/` now point to `v1.1.3`.
- [ ] Maintainer to confirm via CI that the templated workflows still run correctly with this version (these are reusable templates invoked by other repos, so I could not trigger a live run of them from this fork).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated nine reusable workflow templates from `ballerina-platform/setup-ballerina@v1.1.0` to `@v1.1.3`.
- Standardized all 17 `setup-ballerina` references in `.github/workflows/`.
- Enabled workflow templates to build with the nightly Docker image.
- CI validation remains pending because other repositories invoke these templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->