### PR TITLE
Bound waitForRegeneration() polling with a maximum attempt count

### DIFF
--- a/regenerate-openapi-connectors/main.bal
+++ b/regenerate-openapi-connectors/main.bal
@@ -35,6 +35,7 @@ const string REGENERATION_BRANCH = "regenerate-connector";
 
 const decimal WORKFLOW_START_WAIT_TIME = 5;
 const decimal WORKFLOW_POLL_INTERVAL = 5;
+const int MAX_POLL_ATTEMPTS = 360;
 
 configurable string token = os:getEnv(ACCESS_TOKEN_ENV);
 
@@ -97,9 +98,17 @@ isolated function waitForRegeneration(ProcessingModule[] processingModules) retu
     printInfo(string `Waiting for module regeneration to complete`);
     int processedCount = 0;
     int totalModules = processingModules.length();
+    int pollAttempts = 0;
     (Module|error)[] regeneratedModules = [];
     while processedCount < totalModules {
+        if pollAttempts >= MAX_POLL_ATTEMPTS {
+            foreach ProcessingModule processingModule in processingModules {
+                regeneratedModules.push(error(string `Timed out waiting for module regeneration: ${processingModule.module.name}`));
+            }
+            break;
+        }
         runtime:sleep(WORKFLOW_POLL_INTERVAL);
+        pollAttempts += 1;
         // Cloning the array to avoid concurrent modification
         ProcessingModule[] newProcessingModules = processingModules.clone();
         foreach ProcessingModule processingModule in newProcessingModules {


### PR DESCRIPTION
## Summary

Fixes #8991.

`waitForRegeneration()` in `regenerate-openapi-connectors/main.bal` polls each dispatched module regeneration workflow every `WORKFLOW_POLL_INTERVAL` (5s) in a `while processedCount < totalModules` loop with no upper bound. If a dispatched workflow for any module never reaches a `completed` status, that module's count is never incremented, the loop never exits, and `logProcessedModules()` is never called, so even modules that did finish successfully never get reported.

## Change

- Added `MAX_POLL_ATTEMPTS` (360, which at the existing 5s poll interval is 30 minutes).
- Track `pollAttempts` and check it at the top of the loop. Once the limit is reached, every module still in `processingModules` (i.e. still pending) is recorded as a timeout error in `regeneratedModules`, then the loop breaks.
- `logProcessedModules()` still runs afterward as before, now guaranteed to receive a result (success, workflow error, or timeout) for every module rather than potentially never running at all.

## Test plan

I don't have the Ballerina toolchain available in this environment, so I could not run `bal build`/`bal test` directly. To reduce risk:

- [x] Every new construct (`error(string `...`)`, `+= 1`, `if`/`break`) matches an existing, already-working pattern elsewhere in this same file (e.g. `triggerModuleRegeneration()` already constructs errors the same way).
- [x] Traced through the control flow by hand for both the normal-completion path and the new timeout path to confirm no module can be double-counted (successfully processed modules are removed from `processingModules` before the timeout check would ever see them again).
- [ ] Maintainer/CI to confirm this compiles and behaves as expected, since I couldn't verify with the actual compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Bound `waitForRegeneration()` to 360 polling attempts, or 30 minutes at the current interval.
- Mark modules that remain pending as timed out when the limit is reached.
- Ensure `logProcessedModules()` reports successful, failed, and timed-out modules.
- Prevent indefinite CI execution during module regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
