### PR TITLE
Add additional-env-variables input to dev/stage central publish template

### DIFF
--- a/.github/workflows/dev-stage-central-publish-connector-template.yml
+++ b/.github/workflows/dev-stage-central-publish-connector-template.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: string
         default: ""
+      additional-env-variables:
+        description: 'JSON object of extra environment variables to set for the build/publish steps, e.g. {"CENTRAL_VERBOSE_ENABLED": "true"}'
+        required: false
+        type: string
+        default: ""
     secrets:
       BALLERINA_BOT_TOKEN:
         required: true
@@ -50,7 +55,12 @@ jobs:
   
       - name: Set ENV Variables
         run: |
-          echo -e '${{ toJson(secrets) }}' | jq -r 'to_entries[] | .key + "=" + .value' >> $GITHUB_ENV 
+          echo -e '${{ toJson(secrets) }}' | jq -r 'to_entries[] | .key + "=" + .value' >> $GITHUB_ENV
+
+      - name: Set Additional ENV Variables
+        if: ${{ inputs.additional-env-variables != '' }}
+        run: |
+          echo -e '${{ inputs.additional-env-variables }}' | jq -r 'to_entries[] | .key + "=" + .value' >> $GITHUB_ENV
 
       - name: Ballerina Central Dev Push
         if: ${{ inputs.environment == 'DEV CENTRAL' }}


### PR DESCRIPTION
## Summary

Fixes #7524.

All stdlib and connector publishing workflows call `dev-stage-central-publish-connector-template.yml`, which only accepted an `additional-publish-flags` input for the gradle build/publish step. There was no way to set other environment variables needed for debugging purposes, for example enabling debug logs for the central client via `CENTRAL_VERBOSE_ENABLED=true`.

## Change

- Added an optional `additional-env-variables` input (a JSON object string, defaulting to `""`), structured the same way as the existing `additional-publish-flags` input.
- Added a `Set Additional ENV Variables` step, guarded by `if: inputs.additional-env-variables != ''`, that appends the parsed key/value pairs to `GITHUB_ENV` using the same `toJson(...) | jq -r 'to_entries[] | .key + "=" + .value'` pattern already used for `secrets` in this file, so it's applied consistently before both the Dev and Stage publish steps.

This is purely additive: existing callers that don't pass the new input get the default empty string and the new step is skipped, so there's no behavior change for them.

## Test plan

- [x] Parsed the updated workflow with PyYAML to confirm it's valid YAML and the new input/step are structured correctly.
- [ ] Maintainer/CI to confirm a caller passing `additional-env-variables` actually sees those variables set during the build/publish steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds an optional `additional-env-variables` JSON input to the shared Dev and Stage Central publish workflow. The workflow appends the provided variables to `GITHUB_ENV` before publishing. Existing callers keep the default empty value and unchanged behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->